### PR TITLE
Include folly/Portability.h to support gflags >= 2.1

### DIFF
--- a/proxygen/httpserver/samples/echo/EchoServer.cpp
+++ b/proxygen/httpserver/samples/echo/EchoServer.cpp
@@ -12,6 +12,7 @@
 #include "proxygen/httpserver/HTTPServer.h"
 #include "proxygen/httpserver/RequestHandlerFactory.h"
 
+#include <folly/Portability.h>
 #include <folly/Memory.h>
 #include <folly/io/async/EventBaseManager.h>
 #include <unistd.h>
@@ -51,7 +52,7 @@ class EchoHandlerFactory : public RequestHandlerFactory {
 };
 
 int main(int argc, char* argv[]) {
-  google::ParseCommandLineFlags(&argc, &argv, true);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
   google::InitGoogleLogging(argv[0]);
   google::InstallFailureSignalHandler();
 

--- a/proxygen/lib/ssl/test/SSLCacheTest.cpp
+++ b/proxygen/lib/ssl/test/SSLCacheTest.cpp
@@ -7,6 +7,7 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
+#include <folly/Portability.h>
 #include <folly/io/async/EventBase.h>
 #include <gflags/gflags.h>
 #include <iostream>
@@ -96,10 +97,10 @@ public:
 int
 main(int argc, char* argv[])
 {
-  google::SetUsageMessage(std::string("\n\n"
+  gflags::SetUsageMessage(std::string("\n\n"
 "usage: sslcachetest [options] -c <clients> -t <threads> servers\n"
 ));
-  google::ParseCommandLineFlags(&argc, &argv, true);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
   int reqs = 0;
   int hits = 0;
   int miss = 0;

--- a/proxygen/lib/test/TestMain.cpp
+++ b/proxygen/lib/test/TestMain.cpp
@@ -8,13 +8,14 @@
  *
  */
 // Use this main function in gtest unit tests to enable glog
+#include <folly/Portability.h>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
 int main(int argc, char* argv[]) {
   testing::InitGoogleTest(&argc, argv);
-  google::ParseCommandLineFlags(&argc, &argv, true);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
   google::InitGoogleLogging(argv[0]);
   google::InstallFailureSignalHandler();
   LOG(INFO) << "Running tests from TestMain.cpp";


### PR DESCRIPTION
google-gflags changed it's namespace from ::google to ::gflags.  Both cases can be supported by including folly/Portability.h.

Built with gflags-2.0 and gflags-2.1.1 (both on CentOS 7).
