### PR TITLE
Change http to https, make installation of glog, gflags and double-conversion consistent; use github url for double-conversion

### DIFF
--- a/proxygen/deps.sh
+++ b/proxygen/deps.sh
@@ -59,8 +59,8 @@ fi
 if  ! sudo apt-get install libdouble-conversion-dev;
 then
 	if [ ! -e double-conversion ]; then
-                echo "Fetching double-conversion from svn (apt-get failed)"
-		git clone https://code.google.com/p/double-conversion double-conversion
+                echo "Fetching double-conversion from git (apt-get failed)"
+		git clone https://github.com/floitsch/double-conversion.git double-conversion
 		cd double-conversion
 		cmake . -DBUILD_SHARED_LIBS=ON
 		sudo make install


### PR DESCRIPTION
To fix the error:

sudo: apt-get: command not found
fetching glog from svn (apt-get fails)
svn: E175002: Unable to connect to a repository at URL 'http://google-glog.googlecode.com/svn/trunk'
svn: E175002: OPTIONS of 'http://google-glog.googlecode.com/svn/trunk': Could not read status line: connection was closed by server (http://google-glog.googlecode.com)
