### PR TITLE
Fix deps in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu
 RUN apt-get update
 RUN apt-get install -yq git
 RUN apt-get install -yq curl
+RUN apt-get install -yq cmake build-essential
 RUN apt-get install -yq \
     flex \
     bison \


### PR DESCRIPTION
Missing cmake and build-essential dependencies in the current dockerfile in order to be able to compile: double-conversion
