### PR TITLE
[README] Add svg travis build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We have a Google group for general discussions at https://groups.google.com/d/fo
 The [original blog post](https://code.facebook.com/posts/1503205539947302)
 also has more background on the project.
 
-Build Status: [![Build Status](https://travis-ci.org/facebook/proxygen.png?branch=master)](https://travis-ci.org/facebook/proxygen)
+Build Status: [![Build Status](https://travis-ci.org/facebook/proxygen.svg?branch=master)](https://travis-ci.org/facebook/proxygen)
 
 ### Installing
 


### PR DESCRIPTION
Since Github does not support IE 7 or 8, adding the higher resolution svg build badge status seems appropriate.