### PR TITLE
Use os.path.basename to get the base file name to build class name

### DIFF
--- a/proxygen/httpserver/HTTPServer.cpp
+++ b/proxygen/httpserver/HTTPServer.cpp
@@ -9,7 +9,6 @@
  */
 #include <proxygen/httpserver/HTTPServer.h>
 
-#include <boost/thread.hpp>
 #include <folly/ThreadName.h>
 #include <folly/io/async/EventBaseManager.h>
 #include <proxygen/httpserver/HTTPServerAcceptor.h>

--- a/proxygen/httpserver/samples/echo/EchoServer.cpp
+++ b/proxygen/httpserver/samples/echo/EchoServer.cpp
@@ -7,6 +7,7 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
+#include <gflags/gflags.h>
 #include <folly/Memory.h>
 #include <folly/Portability.h>
 #include <folly/io/async/EventBaseManager.h>

--- a/proxygen/lib/http/session/HTTPUpstreamSession.cpp
+++ b/proxygen/lib/http/session/HTTPUpstreamSession.cpp
@@ -9,7 +9,6 @@
  */
 #include <proxygen/lib/http/session/HTTPUpstreamSession.h>
 
-#include <boost/cast.hpp>
 #include <folly/wangle/acceptor/ConnectionManager.h>
 #include <proxygen/lib/http/session/HTTPTransaction.h>
 

--- a/proxygen/lib/services/WorkerThread.cpp
+++ b/proxygen/lib/services/WorkerThread.cpp
@@ -9,7 +9,6 @@
  */
 #include <proxygen/lib/services/WorkerThread.h>
 
-#include <boost/thread.hpp>
 #include <folly/String.h>
 #include <folly/io/async/EventBaseManager.h>
 #include <glog/logging.h>

--- a/proxygen/lib/utils/gen_trace_event_constants.py
+++ b/proxygen/lib/utils/gen_trace_event_constants.py
@@ -33,7 +33,7 @@ def main(argv):
     file_names = options.input_files.split(",")
     for file_name in file_names:
         # strip the file extension and use the file name for class name
-        class_name = file_name.split(".")[0]
+        class_name = os.path.basename(file_name).split(".")[0]
 
         # parse items from source
         items = []


### PR DESCRIPTION
name. Because some build environment may generate code in a different
directory, like
https://github.com/mzhaom/trunk/blob/master/third_party/proxygen/BUILD