### PR TITLE
Allow passing the environment variables used as arguments to the generation scripts

### DIFF
--- a/proxygen/lib/http/gen_HTTPCommonHeaders.cpp.sh
+++ b/proxygen/lib/http/gen_HTTPCommonHeaders.cpp.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+if [ "x$1" != "x" ];then
+	export HEADERS_LIST="$1"
+fi
+if [ "x$2" != "x" ];then
+	export FBCODE_DIR="$2"
+fi
+if [ "x$3" != "x" ];then
+	export INSTALL_DIR="$3"
+fi
+if [ "x$4" != "x" ];then
+	export GPERF="$4"
+else
+	export GPERF="gperf"
+fi
+
 # Some fun stuff going on here.
 #
 # 1) The `cat` here isn't useless, despite what it may seem. Also, the

--- a/proxygen/lib/http/gen_HTTPCommonHeaders.h.sh
+++ b/proxygen/lib/http/gen_HTTPCommonHeaders.h.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+if [ "x$1" != "x" ];then
+	export HEADERS_LIST="$1"
+fi
+if [ "x$2" != "x" ];then
+	export FBCODE_DIR="$2"
+fi
+if [ "x$3" != "x" ];then
+	export INSTALL_DIR="$3"
+fi
+
 # gen_HTTPCommonHeaders.cpp.sh contains a substantially similar pipeline and
 # awk script -- see comments there.
 cat ${HEADERS_LIST?} | sort | uniq \


### PR DESCRIPTION
Because you can't set environment variables from CMake when calling a bash script on Windows.