### PR TITLE
Remove a set of unneeded typename modifiers

### DIFF
--- a/proxygen/lib/http/session/HTTPTransactionEgressSM.cpp
+++ b/proxygen/lib/http/session/HTTPTransactionEgressSM.cpp
@@ -15,8 +15,8 @@ namespace proxygen {
 
 namespace {
 
-typedef typename HTTPTransactionEgressSMData::State State;
-typedef typename HTTPTransactionEgressSMData::Event Event;
+typedef HTTPTransactionEgressSMData::State State;
+typedef HTTPTransactionEgressSMData::Event Event;
 typedef std::map<std::pair<State, Event>, State> TransitionTable;
 
 DEFINE_UNION_STATIC_CONST_NO_INIT(TransitionTable, Table, s_transitions);

--- a/proxygen/lib/http/session/HTTPTransactionIngressSM.cpp
+++ b/proxygen/lib/http/session/HTTPTransactionIngressSM.cpp
@@ -15,8 +15,8 @@ namespace proxygen {
 
 namespace {
 
-typedef typename HTTPTransactionIngressSMData::State State;
-typedef typename HTTPTransactionIngressSMData::Event Event;
+typedef HTTPTransactionIngressSMData::State State;
+typedef HTTPTransactionIngressSMData::Event Event;
 typedef std::map<std::pair<State, Event>, State> TransitionTable;
 
 DEFINE_UNION_STATIC_CONST_NO_INIT(TransitionTable, Table, s_transitions);


### PR DESCRIPTION
MSVC errors if we leave these here, because they aren't needed.