### PR TITLE
Fix the typedefs in http_parser under MSVC 2015

### DIFF
--- a/proxygen/external/http_parser/http_parser.h
+++ b/proxygen/external/http_parser/http_parser.h
@@ -25,7 +25,11 @@
 #define HTTP_PARSER_VERSION_MINOR 0
 
 #include <sys/types.h>
-#if defined(_WIN32) && !defined(__MINGW32__)
+#if defined(_MSC_VER) && _MSC_VER >= 1900
+#include <stdint.h>
+#include <basetsd.h>
+typedef SSIZE_T ssize_t;
+#elif defined(_WIN32) && !defined(__MINGW32__)
 typedef __int8 int8_t;
 typedef unsigned __int8 uint8_t;
 typedef __int16 int16_t;


### PR DESCRIPTION
The only one of these definitions that's actually needed is `ssize_t`, because MSVC defines it in an odd place with a different name.