### PR TITLE
Fix: HTTPAcceptor::init make_unique usage

### DIFF
--- a/proxygen/lib/services/HTTPAcceptor.h
+++ b/proxygen/lib/services/HTTPAcceptor.h
@@ -40,12 +40,12 @@ class HTTPAcceptor : public wangle::Acceptor {
   void init(folly::AsyncServerSocket* serverSocket,
             folly::EventBase* eventBase) override {
     Acceptor::init(serverSocket, eventBase);
-    transactionTimeouts_ =
-       folly::make_unique<folly::HHWheelTimer, folly::HHWheelTimer::Destructor>(
+    transactionTimeouts_ = std::unique_ptr<folly::HHWheelTimer, folly::HHWheelTimer::Destructor>(
+      new folly::HHWheelTimer(
         eventBase,
         std::chrono::milliseconds(folly::HHWheelTimer::DEFAULT_TICK_INTERVAL),
         folly::AsyncTimeout::InternalEnum::NORMAL,
-        accConfig_.transactionIdleTimeout);
+        accConfig_.transactionIdleTimeout));
 
   }
 


### PR DESCRIPTION
The folly::make_unique now conforms to std::make_unique. This means you cannot
specify a deleter function when using make_unique. So just used standard
uninue_ptr constructor with the deleter template.