### PR TITLE
Switch uses of __attribute__((__constructor__)) to dynamic initializers

### DIFF
--- a/proxygen/lib/http/HTTPHeaders.cpp
+++ b/proxygen/lib/http/HTTPHeaders.cpp
@@ -27,19 +27,21 @@ bitset<256>& HTTPHeaders::perHopHeaderCodes() {
   return perHopHeaderCodes;
 }
 
-void
-HTTPHeaders::initGlobals() {
-  auto& perHopHeaders = perHopHeaderCodes();
-  perHopHeaders[HTTP_HEADER_CONNECTION] = true;
-  perHopHeaders[HTTP_HEADER_KEEP_ALIVE] = true;
-  perHopHeaders[HTTP_HEADER_PROXY_AUTHENTICATE] = true;
-  perHopHeaders[HTTP_HEADER_PROXY_AUTHORIZATION] = true;
-  perHopHeaders[HTTP_HEADER_PROXY_CONNECTION] = true;
-  perHopHeaders[HTTP_HEADER_TE] = true;
-  perHopHeaders[HTTP_HEADER_TRAILER] = true;
-  perHopHeaders[HTTP_HEADER_TRANSFER_ENCODING] = true;
-  perHopHeaders[HTTP_HEADER_UPGRADE] = true;
-}
+static struct HTTPHeadersInitGlobals {
+public:
+  HTTPHeadersInitGlobals() {
+    auto& perHopHeaders = HTTPHeaders::perHopHeaderCodes();
+    perHopHeaders[HTTP_HEADER_CONNECTION] = true;
+    perHopHeaders[HTTP_HEADER_KEEP_ALIVE] = true;
+    perHopHeaders[HTTP_HEADER_PROXY_AUTHENTICATE] = true;
+    perHopHeaders[HTTP_HEADER_PROXY_AUTHORIZATION] = true;
+    perHopHeaders[HTTP_HEADER_PROXY_CONNECTION] = true;
+    perHopHeaders[HTTP_HEADER_TE] = true;
+    perHopHeaders[HTTP_HEADER_TRAILER] = true;
+    perHopHeaders[HTTP_HEADER_TRANSFER_ENCODING] = true;
+    perHopHeaders[HTTP_HEADER_UPGRADE] = true;
+  }
+} s_HTTPHeadersInitGlobals;
 
 HTTPHeaders::HTTPHeaders() :
   deletedCount_(0) {

--- a/proxygen/lib/http/HTTPHeaders.h
+++ b/proxygen/lib/http/HTTPHeaders.h
@@ -266,8 +266,6 @@ class HTTPHeaders {
    */
   bool transferHeaderIfPresent(folly::StringPiece name, HTTPHeaders& dest);
 
-  static void initGlobals() __attribute__ ((__constructor__));
-
   // deletes the strings in headerNames_ that we own
   void disposeOfHeaderNames();
 };

--- a/proxygen/lib/http/HTTPMethod.cpp
+++ b/proxygen/lib/http/HTTPMethod.cpp
@@ -24,12 +24,14 @@ namespace {
 typedef std::vector<std::string> StringVector;
 DEFINE_UNION_STATIC_CONST_NO_INIT(StringVector, Vector, s_methodStrings);
 
-__attribute__((__constructor__))
-void initMethodStrings() {
-  new (const_cast<StringVector*>(&s_methodStrings.data)) StringVector {
-    HTTP_METHOD_GEN(HTTP_METHOD_STR)
-  };
-}
+static struct InitMethodStrings {
+public:
+  InitMethodStrings() {
+    new (const_cast<StringVector*>(&s_methodStrings.data)) StringVector{
+      HTTP_METHOD_GEN(HTTP_METHOD_STR)
+    };
+  }
+} s_InitMethodStrings;
 
 }
 

--- a/proxygen/lib/http/codec/HTTP1xCodec.cpp
+++ b/proxygen/lib/http/codec/HTTP1xCodec.cpp
@@ -1065,19 +1065,21 @@ HTTP1xCodec::onMessageCompleteCB(http_parser* parser) {
   }
 }
 
-void
-HTTP1xCodec::initParserSettings() {
-  kParserSettings.on_message_begin = HTTP1xCodec::onMessageBeginCB;
-  kParserSettings.on_url = HTTP1xCodec::onUrlCB;
-  kParserSettings.on_header_field = HTTP1xCodec::onHeaderFieldCB;
-  kParserSettings.on_header_value = HTTP1xCodec::onHeaderValueCB;
-  kParserSettings.on_headers_complete = HTTP1xCodec::onHeadersCompleteCB;
-  kParserSettings.on_body = HTTP1xCodec::onBodyCB;
-  kParserSettings.on_message_complete = HTTP1xCodec::onMessageCompleteCB;
-  kParserSettings.on_reason = HTTP1xCodec::onReasonCB;
-  kParserSettings.on_chunk_header = HTTP1xCodec::onChunkHeaderCB;
-  kParserSettings.on_chunk_complete = HTTP1xCodec::onChunkCompleteCB;
-}
+static struct HTTP1xCodecInitParserSettings {
+public:
+  HTTP1xCodecInitParserSettings() {
+    HTTP1xCodec::kParserSettings.on_message_begin = HTTP1xCodec::onMessageBeginCB;
+    HTTP1xCodec::kParserSettings.on_url = HTTP1xCodec::onUrlCB;
+    HTTP1xCodec::kParserSettings.on_header_field = HTTP1xCodec::onHeaderFieldCB;
+    HTTP1xCodec::kParserSettings.on_header_value = HTTP1xCodec::onHeaderValueCB;
+    HTTP1xCodec::kParserSettings.on_headers_complete = HTTP1xCodec::onHeadersCompleteCB;
+    HTTP1xCodec::kParserSettings.on_body = HTTP1xCodec::onBodyCB;
+    HTTP1xCodec::kParserSettings.on_message_complete = HTTP1xCodec::onMessageCompleteCB;
+    HTTP1xCodec::kParserSettings.on_reason = HTTP1xCodec::onReasonCB;
+    HTTP1xCodec::kParserSettings.on_chunk_header = HTTP1xCodec::onChunkHeaderCB;
+    HTTP1xCodec::kParserSettings.on_chunk_complete = HTTP1xCodec::onChunkCompleteCB;
+  }
+} s_HTTP1xCodecInitParserSettings;
 
 bool HTTP1xCodec::supportsNextProtocol(const std::string& npn) {
   return npn.length() == 8 && (npn == "http/1.0" || npn == "http/1.1");

--- a/proxygen/lib/http/codec/HTTP1xCodec.h
+++ b/proxygen/lib/http/codec/HTTP1xCodec.h
@@ -78,6 +78,8 @@ class HTTP1xCodec : public HTTPCodec {
   static bool supportsNextProtocol(const std::string& npn);
 
  private:
+  friend struct HTTP1xCodecInitParserSettings;
+
   /** Simple state model used to track the parsing of HTTP headers */
   enum class HeaderParseState : uint8_t {
     kParsingHeaderIdle,
@@ -187,8 +189,6 @@ class HTTP1xCodec : public HTTPCodec {
   static int onChunkHeaderCB(http_parser* parser);
   static int onChunkCompleteCB(http_parser* parser);
   static int onMessageCompleteCB(http_parser* parser);
-
-  static void initParserSettings() __attribute__ ((__constructor__));
 
   static http_parser_settings kParserSettings;
 };

--- a/proxygen/lib/http/codec/SPDYCodec.cpp
+++ b/proxygen/lib/http/codec/SPDYCodec.cpp
@@ -157,15 +157,18 @@ class SPDYStreamFailed : public std::exception {
 
 std::bitset<256> SPDYCodec::perHopHeaderCodes_;
 
-void SPDYCodec::initPerHopHeaders() {
-  // SPDY per-hop headers
-  perHopHeaderCodes_[HTTP_HEADER_CONNECTION] = true;
-  perHopHeaderCodes_[HTTP_HEADER_HOST] = true;
-  perHopHeaderCodes_[HTTP_HEADER_KEEP_ALIVE] = true;
-  perHopHeaderCodes_[HTTP_HEADER_PROXY_CONNECTION] = true;
-  perHopHeaderCodes_[HTTP_HEADER_TRANSFER_ENCODING] = true;
-  perHopHeaderCodes_[HTTP_HEADER_UPGRADE] = true;
-}
+static struct SPDYCodecInitPerHopHeaders {
+public:
+  SPDYCodecInitPerHopHeaders() {
+    // SPDY per-hop headers
+    SPDYCodec::perHopHeaderCodes_[HTTP_HEADER_CONNECTION] = true;
+    SPDYCodec::perHopHeaderCodes_[HTTP_HEADER_HOST] = true;
+    SPDYCodec::perHopHeaderCodes_[HTTP_HEADER_KEEP_ALIVE] = true;
+    SPDYCodec::perHopHeaderCodes_[HTTP_HEADER_PROXY_CONNECTION] = true;
+    SPDYCodec::perHopHeaderCodes_[HTTP_HEADER_TRANSFER_ENCODING] = true;
+    SPDYCodec::perHopHeaderCodes_[HTTP_HEADER_UPGRADE] = true;
+  }
+} s_SPDYCodecInitPerHopHeaders;
 
 const SPDYVersionSettings& SPDYCodec::getVersionSettings(SPDYVersion version) {
   // XXX: We new and leak the static here intentionally so it doesn't get

--- a/proxygen/lib/http/codec/SPDYCodec.h
+++ b/proxygen/lib/http/codec/SPDYCodec.h
@@ -130,14 +130,13 @@ public:
   static boost::optional<SPDYVersion> getVersion(const std::string& protocol);
 
  private:
+   friend struct SPDYCodecInitPerHopHeaders;
 
   /**
    * Determines whether header with a given code is on the SPDY per-hop
    * header blacklist.
    */
   static std::bitset<256> perHopHeaderCodes_;
-
-  static void initPerHopHeaders() __attribute__ ((__constructor__));
 
   /**
    * Generates a frame of type SYN_STREAM

--- a/proxygen/lib/http/codec/compress/Huffman.cpp
+++ b/proxygen/lib/http/codec/compress/Huffman.cpp
@@ -310,18 +310,22 @@ const uint8_t s_respBitsTable05[kTableSize] = {
 DEFINE_UNION_STATIC_CONST_NO_INIT(HuffTree, ReqHuffTree, s_reqHuffTree05);
 DEFINE_UNION_STATIC_CONST_NO_INIT(HuffTree, RespHuffTree, s_respHuffTree05);
 
-__attribute__((__constructor__))
-void initReqHuffTree05() {
-  // constructing the tree in-place
-  new (const_cast<HuffTree*>(&s_reqHuffTree05.data))
-    HuffTree(s_reqCodesTable05, s_reqBitsTable05);
-}
+static struct InitReqHuffTree05 {
+public:
+  InitReqHuffTree05() {
+    // constructing the tree in-place
+    new (const_cast<HuffTree*>(&s_reqHuffTree05.data))
+      HuffTree(s_reqCodesTable05, s_reqBitsTable05);
+  }
+} s_InitReqHuffTree05;
 
-__attribute__((__constructor__))
-void initRespHuffTree05() {
-  new (const_cast<HuffTree*>(&s_respHuffTree05.data))
-    HuffTree(s_respCodesTable05, s_respBitsTable05);
-}
+static struct InitRespHuffTree05 {
+public:
+  InitRespHuffTree05() {
+    new (const_cast<HuffTree*>(&s_respHuffTree05.data))
+      HuffTree(s_respCodesTable05, s_respBitsTable05);
+  }
+} s_InitRespHuffTree05;
 
 const HuffTree& reqHuffTree05() {
   return s_reqHuffTree05.data;

--- a/proxygen/lib/http/codec/compress/StaticHeaderTable.cpp
+++ b/proxygen/lib/http/codec/compress/StaticHeaderTable.cpp
@@ -91,12 +91,14 @@ const int kEntriesSize = sizeof(s_tableEntries) / (2 * sizeof(const char*));
  */
 DEFINE_UNION_STATIC_CONST_NO_INIT(StaticHeaderTable, StaticTable, s_table);
 
-__attribute__((__constructor__))
-void initStaticTable() {
-  // use placement new to initialize the static table
-  new (const_cast<StaticHeaderTable*>(&s_table.data))
-    StaticHeaderTable(s_tableEntries, kEntriesSize);
-}
+static struct InitStaticTable {
+public:
+  InitStaticTable() {
+    // use placement new to initialize the static table
+    new (const_cast<StaticHeaderTable*>(&s_table.data))
+      StaticHeaderTable(s_tableEntries, kEntriesSize);
+  }
+} s_InitStaticTable;
 
 StaticHeaderTable::StaticHeaderTable(
     const char* entries[][2],

--- a/proxygen/lib/http/codec/compress/experimental/hpack9/Huffman.cpp
+++ b/proxygen/lib/http/codec/compress/experimental/hpack9/Huffman.cpp
@@ -70,11 +70,13 @@ const uint8_t s_bitsTable09[kTableSize] = {
  */
 DEFINE_UNION_STATIC_CONST_NO_INIT(HuffTree, HuffTree09, s_huffTree09);
 
-__attribute__((__constructor__))
-void initHuffTree09() {
-  new (const_cast<HuffTree*>(&s_huffTree09.data))
-    HuffTree(s_codesTable09, s_bitsTable09);
-}
+static struct InitHuffTree09 {
+public:
+  InitHuffTree09() {
+    new (const_cast<HuffTree*>(&s_huffTree09.data))
+      HuffTree(s_codesTable09, s_bitsTable09);
+  }
+} s_InitHuffTree09;
 
 const HuffTree& huffTree09() {
   return s_huffTree09.data;

--- a/proxygen/lib/http/codec/compress/experimental/hpack9/StaticHeaderTable.cpp
+++ b/proxygen/lib/http/codec/compress/experimental/hpack9/StaticHeaderTable.cpp
@@ -86,12 +86,14 @@ const int kEntriesSize = sizeof(s_tableEntries) / (2 * sizeof(const char*));
  */
 DEFINE_UNION_STATIC_CONST_NO_INIT(StaticHeaderTable, StaticTable, s_table);
 
-__attribute__((__constructor__))
-void initStaticTable() {
-  // use placement new to initialize the static table
-  new (const_cast<StaticHeaderTable*>(&s_table.data))
-    StaticHeaderTable(s_tableEntries, kEntriesSize);
-}
+static struct InitStaticTable {
+public:
+  InitStaticTable() {
+    // use placement new to initialize the static table
+    new (const_cast<StaticHeaderTable*>(&s_table.data))
+      StaticHeaderTable(s_tableEntries, kEntriesSize);
+  }
+} s_InitStaticTable;
 
 const HeaderTable& getStaticTable() {
   return s_table.data;

--- a/proxygen/lib/http/codec/experimental/HTTP2Codec.cpp
+++ b/proxygen/lib/http/codec/experimental/HTTP2Codec.cpp
@@ -29,15 +29,18 @@ uint32_t HTTP2Codec::kHeaderSplitSize{http2::kMaxFramePayloadLengthMin};
 
 std::bitset<256> HTTP2Codec::perHopHeaderCodes_;
 
-void HTTP2Codec::initPerHopHeaders() {
-  // HTTP/1.x per-hop headers that have no meaning in HTTP/2
-  perHopHeaderCodes_[HTTP_HEADER_CONNECTION] = true;
-  perHopHeaderCodes_[HTTP_HEADER_HOST] = true;
-  perHopHeaderCodes_[HTTP_HEADER_KEEP_ALIVE] = true;
-  perHopHeaderCodes_[HTTP_HEADER_PROXY_CONNECTION] = true;
-  perHopHeaderCodes_[HTTP_HEADER_TRANSFER_ENCODING] = true;
-  perHopHeaderCodes_[HTTP_HEADER_UPGRADE] = true;
-}
+static struct HTTP2CodecInitPerHopHeaders {
+public:
+  HTTP2CodecInitPerHopHeaders() {
+    // HTTP/1.x per-hop headers that have no meaning in HTTP/2
+    HTTP2Codec::perHopHeaderCodes_[HTTP_HEADER_CONNECTION] = true;
+    HTTP2Codec::perHopHeaderCodes_[HTTP_HEADER_HOST] = true;
+    HTTP2Codec::perHopHeaderCodes_[HTTP_HEADER_KEEP_ALIVE] = true;
+    HTTP2Codec::perHopHeaderCodes_[HTTP_HEADER_PROXY_CONNECTION] = true;
+    HTTP2Codec::perHopHeaderCodes_[HTTP_HEADER_TRANSFER_ENCODING] = true;
+    HTTP2Codec::perHopHeaderCodes_[HTTP_HEADER_UPGRADE] = true;
+  }
+} s_HTTP2CodecInitPerHopHeaders;
 
 HTTP2Codec::HTTP2Codec(TransportDirection direction)
     : HTTPParallelCodec(direction),

--- a/proxygen/lib/http/codec/experimental/HTTP2Codec.h
+++ b/proxygen/lib/http/codec/experimental/HTTP2Codec.h
@@ -96,6 +96,8 @@ public:
   }
 
  private:
+  friend struct HTTP2CodecInitPerHopHeaders;
+
   class HeaderDecodeInfo {
    public:
     explicit HeaderDecodeInfo(HTTPRequestVerifier v)
@@ -131,8 +133,6 @@ public:
    * header blacklist.
    */
   static std::bitset<256> perHopHeaderCodes_;
-
-  static void initPerHopHeaders() __attribute__ ((__constructor__));
 
   ErrorCode parseFrame(folly::io::Cursor& cursor);
   ErrorCode parseAllData(folly::io::Cursor& cursor);

--- a/proxygen/lib/http/session/HTTPTransactionIngressSM.cpp
+++ b/proxygen/lib/http/session/HTTPTransactionIngressSM.cpp
@@ -31,48 +31,50 @@ DEFINE_UNION_STATIC_CONST_NO_INIT(TransitionTable, Table, s_transitions);
 //             |  +-----> RegularBodyReceived --+  |
 //             |                                   |
 //             +---------> UpgradeComplete --------+
-__attribute__((__constructor__))
-void initTableUnion() {
-  // Use const_cast for the placement new initialization since we want this to
-  // be const after construction.
-  new (const_cast<TransitionTable*>(&s_transitions.data)) TransitionTable {
-    {{State::Start, Event::onHeaders}, State::HeadersReceived},
+static struct InitTableUnion {
+public:
+  InitTableUnion() {
+    // Use const_cast for the placement new initialization since we want this to
+    // be const after construction.
+    new (const_cast<TransitionTable*>(&s_transitions.data)) TransitionTable{
+      {{State::Start, Event::onHeaders}, State::HeadersReceived},
 
-    // For HTTP receiving 100 response, then a regular response
-    {{State::HeadersReceived, Event::onHeaders}, State::HeadersReceived},
+      // For HTTP receiving 100 response, then a regular response
+      {{State::HeadersReceived, Event::onHeaders}, State::HeadersReceived},
 
-    {{State::HeadersReceived, Event::onBody}, State::RegularBodyReceived},
-    {{State::HeadersReceived, Event::onChunkHeader},
-     State::ChunkHeaderReceived},
-    // special case - 0 byte body with trailers
-    {{State::HeadersReceived, Event::onTrailers}, State::TrailersReceived},
-    {{State::HeadersReceived, Event::onUpgrade}, State::UpgradeComplete},
-    {{State::HeadersReceived, Event::onEOM}, State::EOMQueued},
+      {{State::HeadersReceived, Event::onBody}, State::RegularBodyReceived},
+      {{State::HeadersReceived, Event::onChunkHeader},
+       State::ChunkHeaderReceived},
+      // special case - 0 byte body with trailers
+      {{State::HeadersReceived, Event::onTrailers}, State::TrailersReceived},
+      {{State::HeadersReceived, Event::onUpgrade}, State::UpgradeComplete},
+      {{State::HeadersReceived, Event::onEOM}, State::EOMQueued},
 
-    {{State::RegularBodyReceived, Event::onBody}, State::RegularBodyReceived},
-    {{State::RegularBodyReceived, Event::onEOM}, State::EOMQueued},
+      {{State::RegularBodyReceived, Event::onBody}, State::RegularBodyReceived},
+      {{State::RegularBodyReceived, Event::onEOM}, State::EOMQueued},
 
-    {{State::ChunkHeaderReceived, Event::onBody}, State::ChunkBodyReceived},
+      {{State::ChunkHeaderReceived, Event::onBody}, State::ChunkBodyReceived},
 
-    {{State::ChunkBodyReceived, Event::onBody}, State::ChunkBodyReceived},
-    {{State::ChunkBodyReceived, Event::onChunkComplete}, State::ChunkCompleted},
+      {{State::ChunkBodyReceived, Event::onBody}, State::ChunkBodyReceived},
+      {{State::ChunkBodyReceived, Event::onChunkComplete}, State::ChunkCompleted},
 
-    {{State::ChunkCompleted, Event::onChunkHeader}, State::ChunkHeaderReceived},
-    // TODO: "trailers" may be received at any time due to the SPDY HEADERS
-    // frame coming at any time. We might want to have a
-    // TransactionStateMachineFactory that takes a codec and generates the
-    // appropriate transaction state machine from that.
-    {{State::ChunkCompleted, Event::onTrailers}, State::TrailersReceived},
-    {{State::ChunkCompleted, Event::onEOM}, State::EOMQueued},
+      {{State::ChunkCompleted, Event::onChunkHeader}, State::ChunkHeaderReceived},
+      // TODO: "trailers" may be received at any time due to the SPDY HEADERS
+      // frame coming at any time. We might want to have a
+      // TransactionStateMachineFactory that takes a codec and generates the
+      // appropriate transaction state machine from that.
+      {{State::ChunkCompleted, Event::onTrailers}, State::TrailersReceived},
+      {{State::ChunkCompleted, Event::onEOM}, State::EOMQueued},
 
-    {{State::TrailersReceived, Event::onEOM}, State::EOMQueued},
+      {{State::TrailersReceived, Event::onEOM}, State::EOMQueued},
 
-    {{State::UpgradeComplete, Event::onBody}, State::UpgradeComplete},
-    {{State::UpgradeComplete, Event::onEOM}, State::EOMQueued},
+      {{State::UpgradeComplete, Event::onBody}, State::UpgradeComplete},
+      {{State::UpgradeComplete, Event::onEOM}, State::EOMQueued},
 
-    {{State::EOMQueued, Event::eomFlushed}, State::ReceivingDone},
-  };
-}
+      {{State::EOMQueued, Event::eomFlushed}, State::ReceivingDone},
+    };
+  }
+} s_InitTableUnion;
 
 } // namespace
 

--- a/proxygen/lib/utils/UnionBasedStatic.h
+++ b/proxygen/lib/utils/UnionBasedStatic.h
@@ -43,16 +43,20 @@ DECLARE_UNION_STATIC_UNION_ARRAY_IMPL(type, size, name) const var;
 // The const_casts are only needed if creating a const union but it's a
 // no-op otherwise so keep it to avoid creating even more macro helpers.
 #define DEFINE_UNION_STATIC_CONSTRUCTOR_IMPL(type, name, var)                 \
-__attribute__((__constructor__))                                              \
-void init##name##Union() {                                                    \
-  new (const_cast<type*>(&var.data)) type();                                  \
-}
+static struct Init##name##Union {                                             \
+public:                                                                       \
+  Init##name##Union() {                                                       \
+    new (const_cast<type*>(&var.data)) type();                                \
+  }                                                                           \
+} s_Init##name##Union;
 
 #define DEFINE_UNION_STATIC_CONSTRUCTOR_ARG_IMPL(type, name, var, ...)        \
-__attribute__((__constructor__))                                              \
-void init##name##Union() {                                                    \
-  new (const_cast<type*>(&var.data)) type(__VA_ARGS__);                       \
-}
+static struct Init##name##Union {                                             \
+public:                                                                       \
+  Init##name##Union() {                                                       \
+    new (const_cast<type*>(&var.data)) type(__VA_ARGS__);                     \
+  }                                                                           \
+} s_Init##name##Union;
 // END IMPLEMENTATION MACROS
 
 // Use var.data to access the actual member of interest. Zero and argument


### PR DESCRIPTION
Because the attribute isn't portable, and the dynamic initializers do the same thing.