### PR TITLE
A few adjustments for MSVC

### DIFF
--- a/proxygen/lib/services/WorkerThread.cpp
+++ b/proxygen/lib/services/WorkerThread.cpp
@@ -10,13 +10,14 @@
 #include <proxygen/lib/services/WorkerThread.h>
 
 #include <folly/String.h>
+#include <folly/Portability.h>
 #include <folly/io/async/EventBaseManager.h>
 #include <glog/logging.h>
 #include <signal.h>
 
 namespace proxygen {
 
-__thread WorkerThread* WorkerThread::currentWorker_ = nullptr;
+FOLLY_TLS WorkerThread* WorkerThread::currentWorker_ = nullptr;
 
 std::atomic_uint WorkerThread::objectCounter_;
 
@@ -92,6 +93,7 @@ void WorkerThread::wait() {
 }
 
 void WorkerThread::setup() {
+#ifndef _MSC_VER
   sigset_t ss;
 
   // Ignore some signals
@@ -107,6 +109,7 @@ void WorkerThread::setup() {
   sigaddset(&ss, SIGCHLD);
   sigaddset(&ss, SIGIO);
   PCHECK(pthread_sigmask(SIG_BLOCK, &ss, nullptr) == 0);
+#endif
 
   // Update the currentWorker_ thread-local pointer
   CHECK(nullptr == currentWorker_);

--- a/proxygen/lib/services/WorkerThread.h
+++ b/proxygen/lib/services/WorkerThread.h
@@ -11,6 +11,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <folly/Portability.h>
 #include <folly/io/async/EventBase.h>
 #include <mutex>
 #include <thread>
@@ -120,7 +121,7 @@ class WorkerThread {
   folly::EventBaseManager* eventBaseManager_{nullptr};
 
   // A thread-local pointer to the current WorkerThread for this thread
-  static __thread WorkerThread* currentWorker_;
+  static FOLLY_TLS WorkerThread* currentWorker_;
 
   // A count of the number of WorkerThreads that have been constructed
   static std::atomic_uint objectCounter_;

--- a/proxygen/lib/utils/HTTPTime.cpp
+++ b/proxygen/lib/utils/HTTPTime.cpp
@@ -10,6 +10,8 @@
 #include <proxygen/lib/utils/HTTPTime.h>
 
 #include <ctime>
+#include <iomanip>
+#include <sstream>
 #include <glog/logging.h>
 
 namespace proxygen {
@@ -22,17 +24,22 @@ folly::Optional<int64_t> parseHTTPDateTime(const std::string& s) {
   }
 
   // Sun, 06 Nov 1994 08:49:37 GMT  ; RFC 822, updated by RFC 1123
-  if (strptime(s.c_str(), "%a, %d %b %Y %H:%M:%S %Z", &tm) != nullptr) {
+  std::istringstream input(s);
+  if (input >> std::get_time(&tm, "%a, %d %b %Y %H:%M:%S %Z")) {
     return folly::Optional<int64_t>(mktime(&tm));
   }
+  input.clear();
 
   // Sunday, 06-Nov-94 08:49:37 GMT ; RFC 850, obsoleted by RFC 1036
-  if (strptime(s.c_str(), "%a, %d-%b-%y %H:%M:%S %Z", &tm) != nullptr) {
+  input.seekg(0);
+  if (input >> std::get_time(&tm, "%a, %d-%b-%y %H:%M:%S %Z")) {
     return folly::Optional<int64_t>(mktime(&tm));
   }
+  input.clear();
 
   // Sun Nov  6 08:49:37 1994       ; ANSI C's asctime() format
-  if(strptime(s.c_str(), "%a %b %d %H:%M:%S %Y", &tm) != nullptr) {
+  input.seekg(0);
+  if(input >> std::get_time(&tm, "%a %b %d %H:%M:%S %Y")) {
     return folly::Optional<int64_t>(mktime(&tm));
   }
 


### PR DESCRIPTION
The first is to use `FOLLY_TLS` rather than `__thread`.
The second is to not try to ignore some signals, because those signals don't exist under MSVC.
The final change is to switch `parseHTTPDateTime` to use the standard C++ function `std::get_time` rather than the posix function `strptime` to parse the times. This is because `strptime` is not available under MSVC. The format parameter of `std::get_time` is [defined](http://en.cppreference.com/w/cpp/io/manip/get_time) to be the same as `strptime`.