### PR TITLE
Adjust a few includes to use the folly portability headers

### DIFF
--- a/proxygen/lib/http/codec/compress/Huffman.cpp
+++ b/proxygen/lib/http/codec/compress/Huffman.cpp
@@ -10,7 +10,7 @@
 #include <proxygen/lib/http/codec/compress/Huffman.h>
 #include <proxygen/lib/utils/UnionBasedStatic.h>
 
-#include <arpa/inet.h>
+#include <folly/SocketPortability.h>
 
 using folly::IOBuf;
 using std::pair;

--- a/proxygen/lib/utils/ParseURL.cpp
+++ b/proxygen/lib/utils/ParseURL.cpp
@@ -10,7 +10,7 @@
 #include <proxygen/lib/utils/ParseURL.h>
 
 #include <algorithm>
-#include <arpa/inet.h>
+#include <folly/SocketPortability.h>
 #include <proxygen/lib/http/codec/SPDYUtil.h>
 #include <proxygen/lib/utils/UtilInl.h>
 

--- a/proxygen/lib/utils/Time.h
+++ b/proxygen/lib/utils/Time.h
@@ -13,6 +13,8 @@
 #include <chrono>
 #include <cinttypes>
 
+#include <folly/CPortability.h>
+
 namespace proxygen {
 
 using SteadyClock = std::chrono::steady_clock;


### PR DESCRIPTION
This is needed because MSVC doesn't provide the inet header, and also has some functions with different names. The portability headers handle the differences in APIs.

This depends on [Folly #287](https://github.com/facebook/folly/pull/287) being merged upstream first.