### PR TITLE
Install filters, to allow library consumption.

### DIFF
--- a/proxygen/httpserver/Makefile.am
+++ b/proxygen/httpserver/Makefile.am
@@ -4,6 +4,9 @@ lib_LTLIBRARIES = libproxygenhttpserver.la
 
 libproxygenhttpserverdir = $(includedir)/proxygen/httpserver
 nobase_libproxygenhttpserver_HEADERS = \
+	filters/DirectResponseHandler.h \
+	filters/RejectConnectFilter.h \
+	filters/ZlibServerFilter.h \
 	Filters.h \
 	HTTPServer.h \
 	HTTPServerAcceptor.h \


### PR DESCRIPTION
I wanted to use the DirectResponseHandler directly from my code instead of re-implementing it. The other filters are also useful when you're not using the HTTPServer class directly.