### PR TITLE
Pass LC_ALL=C to sort, when generating HTTP headers

### DIFF
--- a/proxygen/lib/http/gen_HTTPCommonHeaders.cpp.sh
+++ b/proxygen/lib/http/gen_HTTPCommonHeaders.cpp.sh
@@ -34,7 +34,7 @@ fi
 # (and less hairy honestly) than the massive `sed` pipeline which used to be
 # here. And it really isn't that bad, this is the sort of thing `awk` was
 # designed for.
-cat ${HEADERS_LIST?} | sort | uniq \
+cat ${HEADERS_LIST?} | LC_ALL=C sort | uniq \
 | awk '
   NR == FNR {
     n[FNR] = $1;

--- a/proxygen/lib/http/gen_HTTPCommonHeaders.h.sh
+++ b/proxygen/lib/http/gen_HTTPCommonHeaders.h.sh
@@ -12,7 +12,7 @@ fi
 
 # gen_HTTPCommonHeaders.cpp.sh contains a substantially similar pipeline and
 # awk script -- see comments there.
-cat ${HEADERS_LIST?} | sort | uniq \
+cat ${HEADERS_LIST?} | LC_ALL=C sort | uniq \
 | awk '
   NR == FNR {
     n[FNR] = $1;


### PR DESCRIPTION
sort's output varies depending on the locale (LC_COLLATE in
particular). Pass LC_ALL=C when calling sort, to avoid adding a
locale-based variance to the build. This makes proxygen
reproducible-friendly.

See https://reproducible-builds.org/docs/locales/ for more.