### PR TITLE
include gflags for declare statement and fix chain logic bug

### DIFF
--- a/proxygen/httpclient/samples/curl/CurlClient.cpp
+++ b/proxygen/httpclient/samples/curl/CurlClient.cpp
@@ -1,5 +1,6 @@
 #include "CurlClient.h"
 
+#include <gflags/gflags.h>
 #include <errno.h>
 #include <sys/stat.h>
 
@@ -144,7 +145,7 @@ void CurlClient::onBody(std::unique_ptr<folly::IOBuf> chain) noexcept {
     do {
       cout.write((const char*)p->data(), p->length());
       p = p->next();
-    } while (p->next() != chain.get());
+    } while (p != chain.get());
   }
 }
 


### PR DESCRIPTION
the file CurlClient.cpp uses macros from gflags/gflags.h but does not include that file, this causes a compile time error when using clang++ on Linux. I have also included in this pull request, a fix for facebook/proxygen#91

Thanks
~ ry