### PR TITLE
Install sudo for docker deploys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get install -yq \
     autoconf-archive \
     libevent-dev \
     libgoogle-glog-dev \
-    wget
+    wget \
+    sudo
 WORKDIR /home
 RUN git clone https://github.com/facebook/proxygen.git
 WORKDIR /home/proxygen/proxygen


### PR DESCRIPTION
Install sudo for use by both `proxygen/[ deps | reinstall ].sh` 
during docker deploys current absence of which results in failed builds.

Closes facebook/proxygen#96