### PR TITLE
set hasUpgradeHeader

### DIFF
--- a/proxygen/lib/http/codec/HTTP1xCodec.cpp
+++ b/proxygen/lib/http/codec/HTTP1xCodec.cpp
@@ -432,6 +432,7 @@ HTTP1xCodec::generateHeader(IOBufQueue& writeBuf,
     } else if (code == HTTP_HEADER_UPGRADE && upstream && txn == 1) {
       // save in case we get a 101 Switching Protocols
       upgradeHeader_ = value;
+      hasUpgradeHeader = true;
     } else if (!hasTransferEncodingChunked &&
                code == HTTP_HEADER_TRANSFER_ENCODING) {
       static const string kChunked = "chunked";


### PR DESCRIPTION
It looks like there an error in Connection header treatment in HTTP1xCodec.cpp - when generating the header, 'update' value is replaced with 'keep-alive'
