### PR TITLE
Fix build/test with new location of gmock/gtest

### DIFF
--- a/proxygen/configure.ac
+++ b/proxygen/configure.ac
@@ -229,7 +229,7 @@ AM_CONDITIONAL([HAVE_BITS_FUNCTEXCEPT_H], [test "$ac_cv_header_bits_functexcept"
 
 # Include directory that contains "proxygen" so #include "proxygen/Foo.h" works
 # Also add includes for gmock and gtest
-AM_CPPFLAGS='-I$(top_srcdir)/.. -I$(top_srcdir)/lib/test/gmock-1.7.0/include -I$(top_srcdir)/lib/test/gmock-1.7.0/gtest/include'
+AM_CPPFLAGS='-I$(top_srcdir)/.. -I$(top_srcdir)/lib/test/googletest/googlemock/include -I$(top_srcdir)/lib/test/googletest/googletest/include'
 AM_CPPFLAGS="$AM_CPPFLAGS $CXX_FLAGS $BOOST_CPPFLAGS"
 AC_SUBST([AM_CPPFLAGS])
 

--- a/proxygen/lib/test/Makefile.am
+++ b/proxygen/lib/test/Makefile.am
@@ -1,11 +1,18 @@
 SUBDIRS = .
 
-BUILT_SOURCES = gmock-1.7.0/gtest/src/gtest-all.cc
+GTEST_ALL = googletest/googletest/src/gtest-all.cc
+BUILT_SOURCES = $(GTEST_ALL)
 
-gmock-1.7.0/gtest/src/gtest-all.cc:
-	wget https://googlemock.googlecode.com/files/gmock-1.7.0.zip
-	unzip gmock-1.7.0.zip
-
+$(GTEST_ALL):
+	test -f googletest/.git || \
+		rm -rf googletest && \
+		git clone https://github.com/google/googletest.git
+	(cd googletest && \
+		(git fetch origin || echo "Fetch failed") && \
+		git checkout release-1.8.0 -- && \
+		cmake . && \
+		make \
+		)
 
 check_LTLIBRARIES = libtesttransport.la
 libtesttransport_la_SOURCES = TestAsyncTransport.cpp
@@ -16,11 +23,12 @@ nobase_libtesttransport_HEADERS = TestAsyncTransport.h
 # libgmockgtest.la is gmock + gtest
 
 check_LTLIBRARIES += libgmockgtest.la
-libgmockgtest_la_CPPFLAGS = -Igmock-1.7.0/gtest -Igmock-1.7.0 -Igmock-1.7.0/gtest/include -Igmock-1.7.0/include -lglog
+libgmockgtest_la_CPPFLAGS = -Igoogletest/googletest -Igoogletest/googlemock $(AM_CPPFLAGS)
+libgmockgtest_la_LDFLAGS = -lglog
 
 libgmockgtest_la_SOURCES = \
-	gmock-1.7.0/gtest/src/gtest-all.cc \
-	gmock-1.7.0/src/gmock-all.cc
+	googletest/googletest/src/gtest-all.cc \
+	googletest/googlemock/src/gmock-all.cc
 
 check_LTLIBRARIES += libtestmain.la
 libtestmain_la_SOURCES = TestMain.cpp


### PR DESCRIPTION
GTest is no longer available from googlecode.com. Changed to use the repo from github.

Might not be an ideal way to load the dependency (I suppose I should add it to deps.sh instead) but it works.

Fixes #112.