### PR TITLE
Conf websocket

### DIFF
--- a/proxygen/httpserver/HTTPServerAcceptor.cpp
+++ b/proxygen/httpserver/HTTPServerAcceptor.cpp
@@ -37,7 +37,9 @@ AcceptorConfiguration HTTPServerAcceptor::makeConfig(
   } else if (ipConfig.protocol == HTTPServer::Protocol::HTTP2) {
     conf.plaintextProtocol = http2::kProtocolCleartextString;
   } else if (opts.h2cEnabled) {
-    conf.allowedPlaintextUpgradeProtocols = { http2::kProtocolCleartextString };
+    conf.allowedPlaintextUpgradeProtocols.push_back(http2::kProtocolCleartextString);
+  } else if (opts.h1xWebsocketEnabled) {
+    conf.allowedPlaintextUpgradeProtocols.push_back("websocket");
   }
 
   conf.sslContextConfigs = ipConfig.sslConfigs;

--- a/proxygen/httpserver/HTTPServerOptions.h
+++ b/proxygen/httpserver/HTTPServerOptions.h
@@ -74,6 +74,11 @@ class HTTPServerOptions {
   bool h2cEnabled{false};
 
   /**
+   * Enable websocket in HTTP/1.x
+   */
+  bool h1xWebsocketEnabled{false};
+
+  /**
    * Signals on which to shutdown the server. Mostly you will want
    * {SIGINT, SIGTERM}. Note, if you have multiple deamons running or you want
    * to have a separate signal handler, leave this empty and handle signals

--- a/proxygen/lib/http/codec/HTTP1xCodec.cpp
+++ b/proxygen/lib/http/codec/HTTP1xCodec.cpp
@@ -919,6 +919,8 @@ HTTP1xCodec::onHeadersComplete(size_t len) {
           // unfortunately have to copy because msg_ is passed to
           // onHeadersComplete
           upgradeRequest_ = folly::make_unique<HTTPMessage>(*msg_);
+        } else if (result) {
+          ingressUpgrade_ = true;
         }
       }
     }


### PR DESCRIPTION
The suggested changes enable HTTP/1.1 websocket support.
The sample reverse proxy with websocket support is available at https://github.com/jhindin/ProxyGenLearing
