### PR TITLE
sfinae expressions generate wrong definitions

### DIFF
--- a/proxygen/lib/utils/FilterChain.h
+++ b/proxygen/lib/utils/FilterChain.h
@@ -295,7 +295,7 @@ class FilterChain: private FilterType {
    * Adds filters with the given types to the front of the chain.
    */
   template<typename C, typename C2, typename... Types>
-  std::enable_if<std::is_constructible<C>::value> addFilters() {
+  typename std::enable_if<std::is_constructible<C>::value>::type addFilters() {
     // Callback <-> F1 <-> F2 ... <-> F_new <-> Destination
     this->append(new C());
     addFilters<C2, Types...>();
@@ -305,7 +305,7 @@ class FilterChain: private FilterType {
    * Base case of above function where we add a single filter.
    */
   template<typename C>
-  std::enable_if<std::is_constructible<C>::value> addFilters() {
+  typename std::enable_if<std::is_constructible<C>::value>::type addFilters() {
     this->append(new C());
   }
 


### PR DESCRIPTION
Sfinae expressions don't work properly and generate wrong definitions for the two functions.
We can further reduce the case to the following example:

    #include <type_traits>
    #include <utility>

    struct S {
        template<typename T>
        std::enable_if<std::is_constructible<T>::value>
        f() {}
    };

    int main() {
        static_assert(std::is_same<decltype(std::declval<S>().f<void>()), std::enable_if<false>>::value, "!");
        static_assert(std::is_same<decltype(std::declval<S>().f<int>()), std::enable_if<true>>::value, "!");
    }

As shown:

* In the first case, the function should be rejected during substitution. Instead it is accepted with a return type `std:.enable_if<false>`.
* In the second case, the expected type is probably `void`, the actual one is `std::enable_if<true>`.

Something similar happens to `FilterChain::addFilters` function templates.

---

I've used the same _C++11-ish_ expressions seen in the whole codebase:

    typename std::enable_if<std::is_constructible<C>::value>::type

Note that it could be replaced by the following one (admitted that the actual revision of the standard required by Proxygen is C++14):

    std::enable_if_t<std::is_constructible<C>::value>