### PR TITLE
Temporarily revert line to fix potential merge conflict

### DIFF
--- a/proxygen/httpclient/samples/curl/CurlClient.cpp
+++ b/proxygen/httpclient/samples/curl/CurlClient.cpp
@@ -160,7 +160,7 @@ void CurlClient::onBody(std::unique_ptr<folly::IOBuf> chain) noexcept {
     do {
       cout.write((const char*)p->data(), p->length());
       p = p->next();
-    } while (p != chain.get());
+    } while (p->next() != chain.get());
   }
 }
 


### PR DESCRIPTION
https://github.com/facebook/proxygen/commit/ce1188743a269266043517aad75b24200227798b
was erroneously merged from github and now we have an inconsistency between internal version and github version. 

Temporarily revert this and will fix internally