### PR TITLE
gtest-all.cc target breaks parallel builds (make -jN)

### DIFF
--- a/proxygen/lib/test/Makefile.am
+++ b/proxygen/lib/test/Makefile.am
@@ -3,9 +3,9 @@ SUBDIRS = .
 BUILT_SOURCES = googletest-release-1.8.0/googletest/src/gtest-all.cc
 
 googletest-release-1.8.0/googletest/src/gtest-all.cc:
-	wget https://github.com/google/googletest/archive/release-1.8.0.zip
+	wget https://github.com/google/googletest/archive/release-1.8.0.zip && \
 	[ "$(shell sha1sum release-1.8.0.zip | awk '{print $$1}')" == \
-	    "667f873ab7a4d246062565fad32fb6d8e203ee73" ]
+	    "667f873ab7a4d246062565fad32fb6d8e203ee73" ] && \
 	unzip release-1.8.0.zip
 
 


### PR DESCRIPTION
Running a build with `make -j4` failed due to the target below being executed in parallel such that the `wget`, `sha1sum` and `unzip` all executed at the same time.

The change below simply combines the three separate steps into one. It's going to make errors a little trickier to investigate should something go wrong with this target, but I anticipate that to be very, very rare.