### PR TITLE
Automatic ETag filter

### DIFF
--- a/proxygen/httpserver/Makefile.am
+++ b/proxygen/httpserver/Makefile.am
@@ -4,6 +4,7 @@ lib_LTLIBRARIES = libproxygenhttpserver.la
 
 libproxygenhttpserverdir = $(includedir)/proxygen/httpserver
 nobase_libproxygenhttpserver_HEADERS = \
+	filters/AutoETag.h \
 	filters/DirectResponseHandler.h \
 	filters/RejectConnectFilter.h \
 	filters/ZlibServerFilter.h \
@@ -22,6 +23,7 @@ nobase_libproxygenhttpserver_HEADERS = \
 	SignalHandler.h
 
 libproxygenhttpserver_la_SOURCES = \
+	filters/AutoETag.cpp \
 	HTTPServer.cpp \
 	HTTPServerAcceptor.cpp \
 	RequestHandlerAdaptor.cpp \

--- a/proxygen/httpserver/filters/AutoETag.cpp
+++ b/proxygen/httpserver/filters/AutoETag.cpp
@@ -1,0 +1,116 @@
+#include <cinttypes>
+
+#include <folly/String.h>
+
+#include "AutoETag.h"
+
+using std::string;
+
+namespace proxygen {
+
+AutoETag::AutoETag(RequestHandler* upstream) : Filter(upstream) {}
+
+void AutoETag::onRequest(std::unique_ptr<HTTPMessage> headers) noexcept {
+  const auto& h = headers->getHeaders();
+
+  if_none_match_.reserve(h.getNumberOfValues(HTTP_HEADER_IF_NONE_MATCH));
+
+  h.forEachValueOfHeader(HTTP_HEADER_IF_NONE_MATCH,
+      [&if_none_match_ = this->if_none_match_](const string& value) -> bool {
+        if (value.find(',') == string::npos) {
+          if_none_match_.push_back(value);
+        } else {
+          std::vector<string> tags;
+          folly::split(string(","), value, tags, true);
+          for (const string& tag: tags) {
+            folly::StringPiece trimmed = folly::trimWhitespace(folly::StringPiece(tag));
+            if_none_match_.emplace_back(trimmed.begin(), trimmed.end());
+          }
+        }
+        return false;
+      });
+
+  upstream_->onRequest(std::move(headers));
+}
+
+void AutoETag::sendHeaders(HTTPMessage& msg) noexcept {
+  HTTPHeaders& headers = msg.getHeaders();
+
+  if (headers.exists(HTTP_HEADER_ETAG)) {
+    const string& etag = headers.getSingleOrEmpty(HTTP_HEADER_ETAG);
+
+    if (etagMatches(etag, if_none_match_)) {
+      send304NotModified(etag);
+      return;
+    }
+  }
+
+  if (msg.getIsChunked()) {
+    // Patch this handler out of the chain.
+    // In future we could send the ETag in a trailer instead.
+    upstream_->setResponseHandler(downstream_);
+    downstream_->sendHeaders(msg);
+    return;
+  }
+
+  msg_ = msg;
+
+  hasher_.Init(0, 0);
+}
+
+void AutoETag::sendBody(std::unique_ptr<folly::IOBuf> body) noexcept {
+  hasher_.Update(body->data(), body->length());
+
+  if (body_)
+    body_->appendChain(std::move(body));
+  else
+    body_ = std::move(body);
+}
+
+void AutoETag::sendEOM() noexcept {
+  uint64_t hash1, hash2;
+  hasher_.Final(&hash1, &hash2);
+
+  // ETags are always quoted-strings
+  string etag = folly::stringPrintf("\"%016" PRIx64, hash1);
+  folly::stringAppendf(&etag, "%016" PRIx64 "\"", hash2);
+
+  if (etagMatches(etag, if_none_match_)) {
+    send304NotModified(etag);
+    return;
+  }
+
+  HTTPHeaders& headers = msg_.getHeaders();
+  headers.set(HTTP_HEADER_ETAG, etag);
+  downstream_->sendHeaders(msg_);
+  downstream_->sendBody(std::move(body_));
+  downstream_->sendEOM();
+}
+
+bool AutoETag::etagMatches(const string& etag, const std::vector<string>& etags) noexcept {
+  for (const auto& tag: etags) {
+    if (tag == etag || tag == "*")
+      return true;
+  }
+
+  return false;
+}
+
+void AutoETag::send304NotModified(const string& etag) noexcept {
+  msg_.setStatusCode(304);
+  msg_.setStatusMessage("Not Modified");
+
+  HTTPHeaders& headers = msg_.getHeaders();
+  headers.remove(HTTP_HEADER_CONTENT_LENGTH);
+  if (!etag.empty())
+    headers.set(HTTP_HEADER_ETAG, etag);
+
+  downstream_->sendHeaders(msg_);
+  downstream_->sendEOM();
+}
+
+RequestHandler* AutoETagFilterFactory::onRequest(RequestHandler* h, HTTPMessage* msg) noexcept {
+  return new AutoETag(h);
+}
+
+}

--- a/proxygen/httpserver/filters/AutoETag.h
+++ b/proxygen/httpserver/filters/AutoETag.h
@@ -50,37 +50,37 @@ namespace proxygen {
  */
 
 class AutoETag : public Filter {
-  public:
-    AutoETag(RequestHandler* upstream);
+public:
+  AutoETag(RequestHandler* upstream);
 
-    void onRequest(std::unique_ptr<HTTPMessage> headers) noexcept override;
+  void onRequest(std::unique_ptr<HTTPMessage> headers) noexcept override;
 
-    void sendHeaders(HTTPMessage& msg) noexcept override;
-    void sendBody(std::unique_ptr<folly::IOBuf> body) noexcept override;
-    void sendEOM() noexcept override;
+  void sendHeaders(HTTPMessage& msg) noexcept override;
+  void sendBody(std::unique_ptr<folly::IOBuf> body) noexcept override;
+  void sendEOM() noexcept override;
 
-  protected:
-    static bool etagMatches(const std::string& etag, const std::vector<std::string>& etags) noexcept;
+ protected:
+  static bool etagMatches(const std::string& etag, const std::vector<std::string>& etags) noexcept;
 
-    virtual void send304NotModified(const std::string& etag) noexcept;
+  virtual void send304NotModified(const std::string& etag) noexcept;
 
-  private:
-    // Request
-    std::vector<std::string> if_none_match_;
+ private:
+  // Request
+  std::vector<std::string> if_none_match_;
 
-    // Response
-    HTTPMessage msg_;
-    std::unique_ptr<folly::IOBuf> body_;
+  // Response
+  HTTPMessage msg_;
+  std::unique_ptr<folly::IOBuf> body_;
 
-    folly::hash::SpookyHashV2 hasher_;
+  folly::hash::SpookyHashV2 hasher_;
 };
 
 class AutoETagFilterFactory : public RequestHandlerFactory {
-  public:
-    void onServerStart(folly::EventBase* evb) noexcept override {}
-    void onServerStop() noexcept override {}
+ public:
+  void onServerStart(folly::EventBase* evb) noexcept override {}
+  void onServerStop() noexcept override {}
 
-    RequestHandler* onRequest(RequestHandler* h, HTTPMessage* msg) noexcept override;
+  RequestHandler* onRequest(RequestHandler* h, HTTPMessage* msg) noexcept override;
 };
 
 }

--- a/proxygen/httpserver/filters/AutoETag.h
+++ b/proxygen/httpserver/filters/AutoETag.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <folly/SpookyHashV2.h>
+
+#include <proxygen/httpserver/Filters.h>
+#include <proxygen/httpserver/RequestHandlerFactory.h>
+
+namespace proxygen {
+
+/**
+ * AutoETag generates ETags for responses and sends back 304 Not Modified
+ * responses to requestors who already have an up-to-date copy of the response.
+ * This can save bandwidth and reduce round-trip-time when reloading an object
+ * that is unchanged.
+ *
+ * It operates by caching the entire response in memory and hashing it before
+ * sending the response. Once the ETag has been calculated, the request is
+ * checked for If-None-Match conditional request headers. If any of the
+ * entity-tags in the If-None-Match header match, a 304 Not Modified response
+ * is sent and the message body is dropped.
+ *
+ * If your objects are large enough that caching them entirely in memory before
+ * sending the response is excessive, it's best to calculate your own ETag
+ * and include it in sendHeaders(). In that case AutoETag will provide the
+ * conditonal response behavior as above, but if the client request does not
+ * match the ETag then AutoETag removes itself from the response chain
+ * altogether.
+ *
+ * AutoETag will also be disabled for responses that are explicitly chunked by
+ * preceding handlers to avoid delaying delivery of each chunk.
+ *
+ * Usage:
+ * There are two ways to use the AutoETag filter. Either globally for all
+ * handlers or on a per-handler basis.
+ *
+ * To enable AutoETag on all requests, add it to the handler factory chain:
+ *   HTTPOptions options;
+ *   options.handlerFactories = RequestHandlerChain()
+ *     .addThen<AutoETagFilterFactory>()
+ *     .addThen<MyHandlerFilterFactory()
+ *     .build();
+ *
+ * To enable AutoETag on a per-handler basis, add it after constructing your
+ * handler in the handler factory:
+ *
+ *   MyHandlerFactory::onRequest() {
+ *     auto myHandler = new MyHandler();
+ *     return new proxygen::AutoETag(myHandler);
+ *   }
+ */
+
+class AutoETag : public Filter {
+  public:
+    AutoETag(RequestHandler* upstream);
+
+    void onRequest(std::unique_ptr<HTTPMessage> headers) noexcept override;
+
+    void sendHeaders(HTTPMessage& msg) noexcept override;
+    void sendBody(std::unique_ptr<folly::IOBuf> body) noexcept override;
+    void sendEOM() noexcept override;
+
+  protected:
+    static bool etagMatches(const std::string& etag, const std::vector<std::string>& etags) noexcept;
+
+    virtual void send304NotModified(const std::string& etag) noexcept;
+
+  private:
+    // Request
+    std::vector<std::string> if_none_match_;
+
+    // Response
+    HTTPMessage msg_;
+    std::unique_ptr<folly::IOBuf> body_;
+
+    folly::hash::SpookyHashV2 hasher_;
+};
+
+class AutoETagFilterFactory : public RequestHandlerFactory {
+  public:
+    void onServerStart(folly::EventBase* evb) noexcept override {}
+    void onServerStop() noexcept override {}
+
+    RequestHandler* onRequest(RequestHandler* h, HTTPMessage* msg) noexcept override;
+};
+
+}

--- a/proxygen/lib/http/HTTPHeaderSet.h
+++ b/proxygen/lib/http/HTTPHeaderSet.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <proxygen/lib/http/HTTPCommonHeaders.h>
+
+#include <bitset>
+
+namespace proxygen {
+
+/**
+ * HTTPHeaderSet is a convenient way to maintain a bitset of headers.
+ * It's a std::bitset with a constructor that allows an initializer list
+ * of header codes to be specified (as true bits).
+ */
+class HTTPHeaderSet: public std::bitset<256> {
+ public:
+  HTTPHeaderSet() = default;
+  HTTPHeaderSet(const HTTPHeaderSet&) = default;
+  HTTPHeaderSet(HTTPHeaderSet&&) = default;
+  HTTPHeaderSet(std::initializer_list<HTTPHeaderCode> lc) :
+    bitset<256>() {
+    for (const auto& code: lc)
+      set(code);
+  }
+};
+
+}

--- a/proxygen/lib/http/HTTPHeaders.cpp
+++ b/proxygen/lib/http/HTTPHeaders.cpp
@@ -9,6 +9,7 @@
  */
 #define PROXYGEN_HTTPHEADERS_IMPL
 #include <proxygen/lib/http/HTTPHeaders.h>
+#include <proxygen/lib/http/HTTPHeaderSet.h>
 
 #include <folly/portability/GFlags.h>
 
@@ -24,23 +25,19 @@ namespace proxygen {
 const string empty_string;
 const std::string HTTPHeaders::COMBINE_SEPARATOR = ", ";
 
-bitset<256>& HTTPHeaders::perHopHeaderCodes() {
-  static bitset<256> perHopHeaderCodes{
-    [] {
-      bitset<256> bs;
-      bs[HTTP_HEADER_CONNECTION] = true;
-      bs[HTTP_HEADER_KEEP_ALIVE] = true;
-      bs[HTTP_HEADER_PROXY_AUTHENTICATE] = true;
-      bs[HTTP_HEADER_PROXY_AUTHORIZATION] = true;
-      bs[HTTP_HEADER_PROXY_CONNECTION] = true;
-      bs[HTTP_HEADER_TE] = true;
-      bs[HTTP_HEADER_TRAILER] = true;
-      bs[HTTP_HEADER_TRANSFER_ENCODING] = true;
-      bs[HTTP_HEADER_UPGRADE] = true;
-      return bs;
-    }()
+const bitset<256>& HTTPHeaders::perHopHeaderCodes() {
+  static const HTTPHeaderSet codes = {
+    HTTP_HEADER_CONNECTION,
+    HTTP_HEADER_KEEP_ALIVE,
+    HTTP_HEADER_PROXY_AUTHENTICATE,
+    HTTP_HEADER_PROXY_AUTHORIZATION,
+    HTTP_HEADER_PROXY_CONNECTION,
+    HTTP_HEADER_TE,
+    HTTP_HEADER_TRAILER,
+    HTTP_HEADER_TRANSFER_ENCODING,
+    HTTP_HEADER_UPGRADE,
   };
-  return perHopHeaderCodes;
+  return codes;
 }
 
 HTTPHeaders::HTTPHeaders() :

--- a/proxygen/lib/http/HTTPHeaders.h
+++ b/proxygen/lib/http/HTTPHeaders.h
@@ -238,7 +238,7 @@ class HTTPHeaders {
    * Determines whether header with a given code is a per-hop header,
    * which should be stripped by stripPerHopHeaders().
    */
-  static std::bitset<256>& perHopHeaderCodes();
+  static const std::bitset<256>& perHopHeaderCodes();
 
  private:
   // vector storing the 1-byte hashes of header names

--- a/proxygen/lib/http/Makefile.am
+++ b/proxygen/lib/http/Makefile.am
@@ -16,6 +16,7 @@ nobase_libproxygenhttp_HEADERS = \
 	HTTPConnector.h \
 	HTTPConstants.h \
 	HTTPException.h \
+	HTTPHeaderSet.h \
 	HTTPHeaderSize.h \
 	HTTPHeaders.h \
 	HTTPMessage.h \

--- a/proxygen/lib/http/test/HTTPHeaderSetTest.cpp
+++ b/proxygen/lib/http/test/HTTPHeaderSetTest.cpp
@@ -1,0 +1,24 @@
+#include <folly/portability/GTest.h>
+
+#include <proxygen/lib/http/HTTPHeaderSet.h>
+
+using namespace proxygen;
+
+TEST(HTTPHeaderSet, constructors) {
+  EXPECT_EQ(HTTPHeaderSet().to_ulong(), 0ul);
+  HTTPHeaderSet s = { HTTP_HEADER_DATE, HTTP_HEADER_EXPIRES };
+  HTTPHeaderSet s2 = s;
+  EXPECT_EQ(s, s2);
+  EXPECT_NE(s.to_ulong(), 0ul);
+
+  HTTPHeaderSet s3(std::move(s2));
+  EXPECT_EQ(s, s3);
+}
+
+TEST(HTTPHeaderSet, bits) {
+  HTTPHeaderSet s { HTTP_HEADER_DATE, HTTP_HEADER_EXPIRES };
+  EXPECT_TRUE(s.test(HTTP_HEADER_DATE));
+  EXPECT_TRUE(s.test(HTTP_HEADER_EXPIRES));
+  EXPECT_FALSE(s.test(HTTP_HEADER_VIA));
+  EXPECT_FALSE(s.test(HTTP_HEADER_HOST));
+}

--- a/proxygen/lib/http/test/Makefile.am
+++ b/proxygen/lib/http/test/Makefile.am
@@ -2,6 +2,7 @@ SUBDIRS = .
 
 check_PROGRAMS = LibHTTPTests
 LibHTTPTests_SOURCES = \
+	HTTPHeaderSetTest.cpp \
 	HTTPMessageTest.cpp \
 	RFC2616Test.cpp \
 	WindowTest.cpp


### PR DESCRIPTION
I wrote a filter that automatically generates ETags when delivering content to allow HTTP clients to make conditional requests and avoid transferring the entire object if it's unchanged.

It checks the incoming request's `If-None-Match` header to determine whether to return a `304 Not Modified` response to the client. (Alternatively a front-end cache may use the ETag to return the `304 Not Modified` response itself.)

The filter can be added globally or for individual handlers.

The ETag response header can be set manually by a handler; in that case this filter will not modify the ETag.

Full documentation is in the `AutoETag.h` header.

I haven't had the opportunity to write a suite of automated tests for this; it has only received manual testing. I thought you might be interested in it anyway.