### PR TITLE
Fix the second parameter to inflateInit2

### DIFF
--- a/proxygen/lib/http/codec/compress/GzipHeaderCodec.cpp
+++ b/proxygen/lib/http/codec/compress/GzipHeaderCodec.cpp
@@ -140,7 +140,7 @@ static const ZlibContext* getZlibContext(SPDYVersionSettings versionSettings,
     // double it if necessary
     newContext->inflater.reserved = 0x01;
 #endif
-    r = inflateInit2(&(newContext->inflater), 0);
+    r = inflateInit2(&(newContext->inflater), MAX_WBITS);
     CHECK_EQ(r, Z_OK);
 
     auto result = newContext.get();


### PR DESCRIPTION
I'm compiling Proxygen on a system that has an older version of Zlib
(1.2.3). This version doesn't select a default value for windowBits when
the value is out of range, resulting in a crash in CodecTests.

From the Zlib manual:

    The windowBits parameter is the base two logarithm of the maximum
    window size (the size of the history buffer).  It should be in the
    range 8..15 for this version of the library. The default value is 15
    if inflateInit is used instead.

For this fix I selected MAX_WBITS, i.e. 15, which appears to be the
value being used when 0 is passed in. The manual continues on:

    windowBits can also be greater than 15 for optional gzip decoding.
    Add 32 to windowBits to enable zlib and gzip decoding with automatic
    header detection, or add 16 to decode only the gzip format (the zlib
    format will return a Z_DATA_ERROR).

It isn't clear to me if something extra needs to be done to enable gzip
decoding. For the record, I tested with:

* MAX_WBITS+16, which resulted in a failure
* MAX_WBITS+32, which worked

I settled on MAX_WBITS since it appears to most closely match the
current behavior.