### PR TITLE
Changes to build this on Centos 6.7

### DIFF
--- a/proxygen/configure.ac
+++ b/proxygen/configure.ac
@@ -40,32 +40,31 @@ CXXFLAGS="-pthread $CXXFLAGS"
 CFLAGS="-DLIBMC_FBTRACE_DISABLE $CFLAGS"
 
 # Checks for libraries.
-AC_CHECK_LIB([glog],[openlog],[],[AC_MSG_ERROR(
-             [Please install google-glog library])])
+AC_CHECK_LIB([glog],[openlog],[],AC_MSG_ERROR(
+             [Please install google-glog library]))
 AC_CHECK_LIB([gflags],[getenv],[],AC_MSG_ERROR(
              [Please install google-gflags library]))
 
 # check for boost libs
-AX_BOOST_BASE([1.51.0], [], [AC_MSG_ERROR(
-              [Please install boost >= 1.51.0])])
+AX_BOOST_BASE([1.51.0], [], AC_MSG_ERROR(
+              [Please install boost >= 1.51.0]))
 
 # Checks for header files.
 AC_HEADER_STDC
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h netdb.h stdint.h string.h sys/file.h sys/time.h syslog.h unistd.h malloc.h])
 
-AC_CHECK_LIB([event], [event_set], [], [AC_MSG_ERROR([Unable to find libevent])])
-AC_CHECK_LIB([cap], [cap_get_proc], [], [AC_MSG_ERROR([Unable to find libcap])])
-AC_CHECK_LIB([crypto], [MD5_Init], [], [AC_MSG_ERROR([Unable to find libcrypto])])
-AC_CHECK_LIB([ssl], [SSL_SESSION_new], [], [AC_MSG_ERROR([Unable to find libssl])])
-AC_CHECK_LIB([z], [gzread], [], [AC_MSG_ERROR([Unable to find zlib])])
-AC_CHECK_LIB([folly],[getenv],[],[AC_MSG_ERROR(
-             [Please install the folly library from https://github.com/facebook/folly])])
-AC_CHECK_LIB([wangle], [getenv], [], [AC_MSG_ERROR(
-             [Please install the wangle library from https://github.com/facebook/wangle])])
-AC_CHECK_HEADER([folly/Likely.h], [], [AC_MSG_ERROR(
-[Couldn't find folly, please download from https://github.com/facebook/folly]
-)], [])
-
+AC_CHECK_LIB([event], [event_set], [], AC_MSG_ERROR([Unable to find libevent]))
+AC_CHECK_LIB([cap], [cap_get_proc], [], AC_MSG_ERROR([Unable to find libcap]))
+AC_CHECK_LIB([crypto], [MD5_Init], [], AC_MSG_ERROR([Unable to find libcrypto]))
+AC_CHECK_LIB([ssl], [SSL_SESSION_new], [], AC_MSG_ERROR([Unable to find libssl]))
+AC_CHECK_LIB([z], [gzread], [], AC_MSG_ERROR([Unable to find zlib]))
+AC_CHECK_LIB([folly],[getenv],[],AC_MSG_ERROR(
+             [Please install the folly library from https://github.com/facebook/folly]))
+AC_CHECK_LIB([wangle], [getenv], [], AC_MSG_ERROR(
+             [Please install the wangle library from https://github.com/facebook/wangle]))
+AC_CHECK_HEADER([folly/Likely.h], [], AC_MSG_ERROR(
+[Couldn't find folly please download from https://github.com/facebook/folly]
+), [])
 # Checks for typedefs, structures, and compiler characteristics.
 AC_HEADER_STDBOOL
 AC_C_CONST


### PR DESCRIPTION
I had to make the following changes to compile this on Centos 6.7

AC_MSG_ERROR should not be inside [] as that gets treated as string.

After fixing the above problem, the following line generated incorrect script.

AC_CHECK_HEADER([folly/Likely.h], [], AC_MSG_ERROR(
[Couldn't find folly, please download from https://github.com/facebook/folly]
), [])

ac_fn_cxx_check_header_compile "$LINENO" "folly/Likely.h" "ac_cv_header_folly_Likely_h" "please download from https://github.com/facebook/folly
\" \"$LINENO\" 5
"
if test "x$ac_cv_header_folly_Likely_h" = xyes; then :

else
  as_fn_error $? "Couldn't find folly
fi

For some reason ',' before please is getting interpreted differently. After removing it generated working code as below:


ac_fn_cxx_check_header_mongrel "$LINENO" "folly/Likely.h" "ac_cv_header_folly_Likely_h" "$ac_includes_default"
if test "x$ac_cv_header_folly_Likely_h" = xyes; then :

else
  as_fn_error $? "Couldn't find folly please download from https://github.com/facebook/folly
" "$LINENO" 5
fi