### PR TITLE
Update the proxygen::HTTPServer::bind() interface

### DIFF
--- a/proxygen/httpserver/HTTPServer.cpp
+++ b/proxygen/httpserver/HTTPServer.cpp
@@ -81,8 +81,12 @@ HTTPServer::~HTTPServer() {
   CHECK(!mainEventBase_) << "Forgot to stop() server?";
 }
 
-void HTTPServer::bind(std::vector<IPConfig> addrs) {
+void HTTPServer::bind(std::vector<IPConfig>&& addrs) {
   addresses_ = std::move(addrs);
+}
+
+void HTTPServer::bind(std::vector<IPConfig> const& addrs) {
+  addresses_ = addrs;
 }
 
 class HandlerCallbacks : public ThreadPoolExecutor::Observer {

--- a/proxygen/httpserver/HTTPServer.h
+++ b/proxygen/httpserver/HTTPServer.h
@@ -87,7 +87,8 @@ class HTTPServer final {
    *
    * Can be called from any thread.
    */
-  void bind(std::vector<IPConfig> addrs);
+  void bind(std::vector<IPConfig>&& addrs);
+  void bind(std::vector<IPConfig> const& addrs);
 
   /**
    * Start HTTPServer.


### PR DESCRIPTION
The `bind()` method accepted a non-const reference. The documentation
claimed the IP list would be update in place, however the actual code
is copying the array and binding later in `start()`.

This change updates the bind interface so that it is a const reference
and adds an overload that takes an rvalue reference. The documentation
is also updated to reflect what is going on.