### PR TITLE
Fixed broken HTTPSession interfaces

### DIFF
--- a/proxygen/lib/http/session/HTTPSession.h
+++ b/proxygen/lib/http/session/HTTPSession.h
@@ -203,6 +203,13 @@ class HTTPSession:
     return false;
   }
 
+  // Returns the number of streams that count against a pipelining limit.
+  // Upstreams can't really pipleine (send responses before requests), so
+  // count ANY stream against the limit.
+  size_t getPipelineStreamCount() const override {
+    return isDownstream() ? incomingStreams_ : transactions_.size();
+  }
+
  protected:
   /**
    * HTTPSession is an abstract base class and cannot be instantiated
@@ -806,13 +813,6 @@ class HTTPSession:
    * transport has become replay safe.
    */
   void onReplaySafe() noexcept override;
-
-  // Returns the number of streams that count against a pipelining limit.
-  // Upstreams can't really pipleine (send responses before requests), so
-  // count ANY stream against the limit.
-  size_t getPipelineStreamCount() const {
-    return isDownstream() ? incomingStreams_ : transactions_.size();
-  }
 
   bool maybeResumePausedPipelinedTransaction(size_t oldStreamCount,
                                              uint32_t txnSeqn);

--- a/proxygen/lib/http/session/HTTPSessionBase.h
+++ b/proxygen/lib/http/session/HTTPSessionBase.h
@@ -138,6 +138,8 @@ class HTTPSessionBase : public wangle::ManagedConnection {
 
   virtual uint32_t getNumIncomingStreams() const = 0;
 
+  virtual const HTTPCodec& getCodec() const noexcept = 0;
+  virtual size_t getPipelineStreamCount() const = 0;
 
   virtual uint32_t getMaxConcurrentOutgoingStreamsRemote() const = 0;
 


### PR DESCRIPTION
I have an active HTTP client which maintains a number of connections to an HTTP server through a connections pool.

To achieve this, we actively use HTTPUpstream and HTTPSession. I have a highly modified version of SessionWrapper borrowed from the proxy sample.

Since the interface has changed and now I have to go through HTTPSessionBase, I found out that a couple of methods we relied on are missing. Specifically getCodec and getPipelineStreamCount.

I've added these 2 methods to HTTPSessionBase as pure virtual functions and make sure they are inherited correctly.