### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,9 @@
 # Contributing to Proxygen
 Here's a quick rundown of how to contribute to this project.
 
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+
 ## Our Development Process
 We develop on a private branch internally at Facebook. We regularly update
 this github project with the changes from the internal repo. External pull


### PR DESCRIPTION
In the past Facebook didn't promote including a Code of Conduct when creating new projects, and many projects skipped this important document. Let's fix it. :)

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve [the proxygen community profile](https://github.com/facebook/proxygen/community)
checklist and increase the visibility of our COC.

**test plan:**
Viewing it on my branch -
<img width="1037" alt="screen shot 2017-12-03 at 5 36 00 pm" src="https://user-images.githubusercontent.com/1114467/33532718-e275d59c-d850-11e7-9e8f-c83bfe478c9c.png">
<img width="1017" alt="screen shot 2017-12-03 at 5 38 04 pm" src="https://user-images.githubusercontent.com/1114467/33532719-e28c9c32-d850-11e7-9f65-c640837004e9.png">

**issue:**
internal task t23481323