### PR TITLE
Compression Simulator changes.

### DIFF
--- a/proxygen/lib/http/Makefile.am
+++ b/proxygen/lib/http/Makefile.am
@@ -158,3 +158,45 @@ libproxygenhttp_la_SOURCES = \
 libproxygenhttp_la_LIBADD = \
 	../services/libproxygenservices.la \
 	../utils/libutils.la
+
+noinst_LTLIBRARIES += libqpack.la
+libqpackdir = $(includedir)/proxygen/lib/http/codec/compress/experimental/qpack
+libqpack_la_SOURCES = \
+	codec/compress/experimental/qpack/QPACKCodec.cpp \
+	codec/compress/experimental/qpack/QPACKContext.cpp \
+	codec/compress/experimental/qpack/QPACKDecoder.cpp \
+	codec/compress/experimental/qpack/QPACKEncoder.cpp \
+	codec/compress/experimental/qpack/QPACKHeaderTable.cpp
+
+libqpack_HEADERS = \
+	codec/compress/experimental/qpack/QPACKCodec.h \
+	codec/compress/experimental/qpack/QPACKContext.h \
+	codec/compress/experimental/qpack/QPACKDecoder.h \
+	codec/compress/experimental/qpack/QPACKHeader.h \
+	codec/compress/experimental/qpack/QPACKHeaderTable.h
+
+libqpack_la_LIBADD = \
+	../utils/libutils.la
+
+noinst_PROGRAMS = CompressionSimulator
+
+CompressionSimulator_SOURCES = \
+	codec/compress/test/HTTPArchive.cpp \
+	codec/compress/experimental/simulator/Main.cpp \
+	codec/compress/experimental/simulator/CompressionSimulator.cpp
+
+CompressionSimulatordir = $(includedir)/proxygen/lib/http/codec/compress/experimental/simulator
+CompressionSimulator_HEADERS = \
+	codec/compress/test/HTTPArchive.h \
+	codec/compress/experimental/simulator/CompressionScheme.h \
+	codec/compress/experimental/simulator/CompressionSimulator.h \
+	codec/compress/experimental/simulator/CompressionTypes.h \
+	codec/compress/experimental/simulator/HPACKScheme.h \
+	codec/compress/experimental/simulator/QCRAMScheme.h \
+	codec/compress/experimental/simulator/QPACKScheme.h \
+	codec/compress/experimental/simulator/SimStreamingCallback.h
+
+CompressionSimulator_LDADD = \
+	libqpack.la \
+	libproxygenhttp.la \
+	../services/libproxygenservices.la

--- a/proxygen/lib/http/codec/compress/experimental/simulator/CompressionSimulator.cpp
+++ b/proxygen/lib/http/codec/compress/experimental/simulator/CompressionSimulator.cpp
@@ -112,6 +112,7 @@ CompressionSimulator::readInputFromFileAndSchedule(const string& filename) {
   TimePoint last = har->requests[0].getStartTime();
   std::chrono::milliseconds cumulativeDelay(0);
   uint16_t index = 0;
+  auto newPacketThreshold = std::chrono::milliseconds(0);
   for (HTTPMessage& msg: har->requests) {
     auto delayFromPrevious = millisecondsBetween(msg.getStartTime(), last);
     // If there was a quiescent gap in the HAR of at least some value, shrink
@@ -122,6 +123,9 @@ CompressionSimulator::readInputFromFileAndSchedule(const string& filename) {
     last = msg.getStartTime();
     cumulativeDelay += delayFromPrevious;
     setupRequest(index++, std::move(msg), cumulativeDelay);
+  }
+  for (auto& kv : domains_) {
+    flushRequests(kv.second.get());
   }
   return true;
 }
@@ -145,6 +149,7 @@ void CompressionSimulator::run() {
     "\nSeed: " << params_.seed <<
     "\nBlocks sent: " << requests_.size() <<
     "\nAllowed OOO: " << stats_.allowedOOO <<
+    "\nPackets: " << stats_.packets <<
     "\nPacket Losses: " << stats_.packetLosses <<
     "\nHOL Block Count: " << holBlockCount <<
     "\nHOL Delay (ms): " << stats_.holDelay.count() <<
@@ -153,6 +158,35 @@ void CompressionSimulator::run() {
     "\nCompressed Bytes: " << stats_.compressed <<
     "\nCompression Ratio: " <<
     int(100 - double(100 * stats_.compressed) / stats_.uncompressed);
+}
+
+void CompressionSimulator::flushRequests(CompressionScheme *scheme) {
+  VLOG(5) << "schedule encode for " << scheme->packetIndices.size() << " blocks at " << scheme->prev.count();
+  // Flush previous train
+  scheduleEvent([this, scheme, indices=std::move(scheme->packetIndices)] () mutable {
+      bool newPacket = true;
+      while (!indices.empty()) {
+        int16_t index = indices.front();
+        indices.pop_front();
+        auto schemeIndex = scheme->index;
+        auto encodeRes = encode(scheme, newPacket, index);
+        FrameFlags flags =encodeRes.first;
+        bool allowOOO = flags.allowOOO;
+        if (schemeIndex < minOOOThresh()) {
+          allowOOO = false;
+          auto ack = scheme->getAck(schemeIndex);
+          if (ack) {
+            scheme->recvAck(std::move(ack));
+          }
+        }
+        stats_.allowedOOO += (allowOOO) ? 1 : 0;
+        flags.allowOOO = allowOOO;
+        scheme->encodedBlocks.emplace_back(
+            flags, newPacket, std::move(encodeRes.second), &callbacks_[index]);
+        newPacket = false;
+      }
+      eventBase_.runInLoop(scheme, true);
+    }, scheme->prev);
 }
 
 void CompressionSimulator::setupRequest(uint16_t index, HTTPMessage&& msg,
@@ -172,23 +206,19 @@ void CompressionSimulator::setupRequest(uint16_t index, HTTPMessage&& msg,
   };
   callbacks_.emplace_back(index, decodeCompleteCB);
 
-  // Schedule the encode event
-  scheduleEvent([index, this, scheme] {
-      auto schemeIndex = scheme->index;
-      auto encodeRes = encode(scheme, index);
-      bool allowOOO = encodeRes.first;
-      if (schemeIndex < minOOOThresh()) {
-        allowOOO = false;
-        auto ack = scheme->getAck(schemeIndex);
-        if (ack) {
-          scheme->recvAck(std::move(ack));
-        }
-      }
-      stats_.allowedOOO += (allowOOO) ? 1 : 0;
-      scheme->encodedBlocks.emplace_back(
-        allowOOO, std::move(encodeRes.second), &callbacks_[index]);
-      eventBase_.runInLoop(scheme, true);
-    }, encodeDelay);
+  // Assume that all packets with same encodeDelay will form a packet
+  // train.  Encode them as a group, so can we can emulate packet
+  // boundaries more realistically, telling the encoder which blocks
+  // start such trains.
+  if (scheme->packetIndices.size() > 0) {
+    auto delayFromPrevious = encodeDelay - scheme->prev;
+    VLOG(1) << "request " << index << " delay " << delayFromPrevious.count();
+    if (delayFromPrevious > std::chrono::milliseconds(5)) {
+      flushRequests(scheme);
+    }
+  }
+  scheme->prev = encodeDelay;
+  scheme->packetIndices.push_back(index);
 }
 
 // Once per loop, each connection flushes it's encode blocks and schedules
@@ -197,62 +227,72 @@ void CompressionScheme::runLoopCallback() noexcept {
   simulator_->flushSchemePackets(this);
 }
 
+void CompressionSimulator::flushPacket(CompressionScheme* scheme) {
+  if (scheme->packetBlocks.empty()) return;
+
+  stats_.packets++;
+  VLOG(1) << "schedule decode for " << scheme->packetBlocks.size() << " blocks at " << scheme->decodeDelay.count();
+  scheduleEvent({[this, scheme, blocks=std::move(scheme->packetBlocks)] () mutable {
+        decodePacket(scheme, blocks);
+      }}, scheme->decodeDelay);
+  scheme->packetBytes = 0;
+}
+
 void CompressionSimulator::flushSchemePackets(CompressionScheme* scheme) {
   CHECK(!scheme->encodedBlocks.empty());
   VLOG(2) << "Flushing " << scheme->encodedBlocks.size() << " requests";
   // tracks the number of bytes in the current simulated packet
-  size_t packetBytes = 0;
   auto encodeRes = &scheme->encodedBlocks.front();
+  bool newPacket = std::get<1>(*encodeRes);
   size_t headerBlockBytesRemaining =
-    std::get<1>(*encodeRes)->computeChainDataLength();
+    std::get<2>(*encodeRes)->computeChainDataLength();
   std::chrono::milliseconds packetDelay = deliveryDelay();
-  std::chrono::milliseconds decodeDelay = packetDelay;
+  scheme->decodeDelay = packetDelay;
   while (true) {
+    if (newPacket) {
+      flushPacket(scheme);
+    }
+    newPacket = false;
+    //    bool fullPacket = false;
     // precondition packetBytes < kMTU
-    bool nextPacket = false;
-    if (packetBytes + headerBlockBytesRemaining >= kMTU) {
+    if (scheme->packetBytes + headerBlockBytesRemaining >= kMTU) {
       // Header block filled current packet, triggering a flush
       VLOG(2) << "Request(s) spanned multiple packets";
-      nextPacket = true;
+      newPacket = true;
     } else {
-      packetBytes += headerBlockBytesRemaining;
+      scheme->packetBytes += headerBlockBytesRemaining;
     }
     headerBlockBytesRemaining -= std::min(headerBlockBytesRemaining,
-                                          kMTU - packetBytes);
+                                          kMTU - scheme->packetBytes);
     if (headerBlockBytesRemaining == 0) {
-      // The entire request has been packetized, schedule the decode
-      scheduleEvent({
-          [this, allowOOO=std::get<0>(*encodeRes),
-           buf=std::move(std::get<1>(*encodeRes)),
-           cb=std::get<2>(*encodeRes), scheme] () mutable {
-            decode(scheme, allowOOO, std::move(buf), *cb);
-          }}, decodeDelay);
-      scheme->encodedBlocks.pop_front();
+      // Move from the first element of encodedBlocks to the last
+      // element of packetBlocks.
+      scheme->packetBlocks.splice(scheme->packetBlocks.end(),
+                                  scheme->encodedBlocks,
+                                  scheme->encodedBlocks.begin());
       if (scheme->encodedBlocks.empty()) {
         // All done
         break;
       }
       // Grab the next request
       encodeRes = &scheme->encodedBlocks.front();
+      newPacket = std::get<1>(*encodeRes);
       headerBlockBytesRemaining =
-        std::get<1>(*encodeRes)->computeChainDataLength();
-      // This new request will either fit entirely in the current packet, or
-      // be in a new packet.  Set its decodeDelay accordingly.
-      decodeDelay = nextPacket ? std::chrono::milliseconds(0) : packetDelay;
+        std::get<2>(*encodeRes)->computeChainDataLength();
     }
-    if (nextPacket) {
-      packetBytes = 0;
+    if (newPacket) {
       packetDelay = deliveryDelay();
-      decodeDelay = std::max(decodeDelay, packetDelay);
+      scheme->decodeDelay = std::max(scheme->decodeDelay, packetDelay);
     }
   }
+  flushPacket(scheme);
   CHECK(scheme->encodedBlocks.empty());
 }
 
 CompressionScheme* CompressionSimulator::getScheme(StringPiece domain) {
   static string blended("\"Facebook\"");
   if (params_.blend &&
-      (domain.endsWith(".facebook.com") || domain.endsWith(".fbcdn.net"))) {
+      (domain.endsWith("facebook.com") || domain.endsWith("fbcdn.net"))) {
     domain = blended;
   }
 
@@ -283,8 +323,9 @@ unique_ptr<CompressionScheme> CompressionSimulator::makeScheme() {
   return nullptr;
 }
 
-std::pair<bool, unique_ptr<IOBuf>>
-CompressionSimulator::encode(CompressionScheme* scheme, uint16_t index) {
+std::pair<FrameFlags, unique_ptr<IOBuf>>
+CompressionSimulator::encode(CompressionScheme* scheme, bool newPacket, uint16_t index) {
+  VLOG(1) << "Start encoding request=" << index;
   vector<compress::Header> allHeaders;
   // The encode API is pretty bad.  We should just let HPACK directly encode
   // HTTP messages
@@ -328,18 +369,40 @@ CompressionSimulator::encode(CompressionScheme* scheme, uint16_t index) {
         allHeaders.emplace_back(code, name, value);
       }
     });
-  auto res = scheme->encode(std::move(allHeaders), stats_);
+
+  auto before = stats_.uncompressed;
+  auto res = scheme->encode(newPacket, std::move(allHeaders), stats_);
   VLOG(1) << "Encoded request=" << index << " for host=" << host
+          << " orig size=" << (stats_.uncompressed - before)
           << " block size=" << res.second->computeChainDataLength()
+          << " cumulative bytes=" << stats_.compressed
           << " cumulative compression ratio=" <<
     int(100 - double(100 * stats_.compressed) / stats_.uncompressed);
   return res;
 }
 
-void CompressionSimulator::decode(CompressionScheme* scheme, bool allowOOO,
+void CompressionSimulator::decode(CompressionScheme* scheme,
+                                  FrameFlags flags,
                                   unique_ptr<IOBuf> encodedReq,
                                   SimStreamingCallback& cb) {
-  scheme->decode(allowOOO, std::move(encodedReq), stats_, cb);
+  scheme->decode(flags, std::move(encodedReq), stats_, cb);
+}
+
+void CompressionSimulator::decodePacket(CompressionScheme* scheme,
+                                        std::list<std::tuple<FrameFlags, bool, std::unique_ptr<folly::IOBuf>, SimStreamingCallback*>>& blocks) {
+  VLOG(1) << "decode packet with " << blocks.size() << " blocks";
+  while (!blocks.empty()) {
+    auto encodeRes = &blocks.front();
+    // TODO(ckrasic) - to get packet coordination correct, could plumb
+    // through "start of packet" flag here.  Probably not worth it,
+    // since it seems to make only a very small difference (about a
+    // 0.1% compressiondifference on my facebook har).
+    decode(scheme,
+           std::get<0>(*encodeRes),
+           std::move(std::get<2>(*encodeRes)),
+           *std::get<3>(*encodeRes));
+    blocks.pop_front();
+  }
 }
 
 void CompressionSimulator::scheduleEvent(folly::Function<void()> f,
@@ -369,9 +432,10 @@ std::chrono::milliseconds CompressionSimulator::deliveryDelay() {
     scheduleEvent([] {
         VLOG(4) << "Packet lost!";
       }, delay);
-    delay += rxmitDelay();
-    scheduleEvent([] {
-        VLOG(4) << "Packet loss detected, retransmitting";
+    std::chrono::milliseconds rxmit = rxmitDelay();
+    delay += rxmit;
+    scheduleEvent([rxmit] {
+        VLOG(4) << "Packet loss detected, retransmitting with additional " << rxmit.count();
       }, delay - one_half_rtt());
   }
   if (delayed()) {

--- a/proxygen/lib/http/codec/compress/experimental/simulator/CompressionSimulator.h
+++ b/proxygen/lib/http/codec/compress/experimental/simulator/CompressionSimulator.h
@@ -32,14 +32,19 @@ class CompressionSimulator {
 
   // Called from CompressionScheme::runLoopCallback
   void flushSchemePackets(CompressionScheme* scheme);
+  void flushPacket(CompressionScheme* scheme);
  private:
+  void flushRequests(CompressionScheme* scheme);
   void setupRequest(uint16_t seqn, HTTPMessage&& msg,
                     std::chrono::milliseconds encodeDelay);
   CompressionScheme* getScheme(folly::StringPiece host);
   std::unique_ptr<CompressionScheme> makeScheme();
-  std::pair<bool, std::unique_ptr<folly::IOBuf>> encode(
-    CompressionScheme* scheme, uint16_t seqn);
-  void decode(CompressionScheme* scheme, bool allowOOO,
+  std::pair<FrameFlags, std::unique_ptr<folly::IOBuf>> encode(
+      CompressionScheme* scheme, bool newPacket, uint16_t seqn);
+  void decodePacket(CompressionScheme* scheme,
+                    std::list<std::tuple<FrameFlags, bool, std::unique_ptr<folly::IOBuf>,
+                    SimStreamingCallback*>>& blocks);
+  void decode(CompressionScheme* scheme, FrameFlags flags,
               std::unique_ptr<folly::IOBuf> encodedReq,
               SimStreamingCallback& cb);
   void scheduleEvent(folly::Function<void()> f, std::chrono::milliseconds ms);

--- a/proxygen/lib/http/codec/compress/experimental/simulator/CompressionTypes.h
+++ b/proxygen/lib/http/codec/compress/experimental/simulator/CompressionTypes.h
@@ -19,6 +19,12 @@ enum class SchemeType {
   HPACK
 };
 
+// Metadata about encoded blocks.  In a real stack, these might be
+// conveyed via HTTP frame (HEADERS or PUSH_PROMISE) flags.
+struct FrameFlags {
+  bool allowOOO{false};
+};
+
 struct SimParams {
   SchemeType type;
   int64_t seed;
@@ -39,5 +45,6 @@ struct SimStats {
   std::chrono::milliseconds holDelay{0};
   uint64_t uncompressed{0};
   uint64_t compressed{0};
+  uint64_t packets{0};
 };
 }}


### PR DESCRIPTION
o extend proxygen/lib/http/Makefile.am to include CompressionSimulator.

o rework packet handling in simulator so that encoder and decoder
  packets are aligned.

o add "FrameFlags" per-header block metadata, mainly in preparation for
  QCRAM.