### PR TITLE
Return session idle time in actual milliseconds

### DIFF
--- a/proxygen/lib/http/session/HTTPSessionBase.h
+++ b/proxygen/lib/http/session/HTTPSessionBase.h
@@ -552,7 +552,7 @@ class HTTPSessionBase : public wangle::ManagedConnection {
   // private ManagedConnection methods
   std::chrono::milliseconds getIdleTime() const override {
     if (timePointInitialized(latestActive_)) {
-      return secondsSince(latestActive_);
+      return millisecondsSince(latestActive_);
     } else {
       return std::chrono::milliseconds(0);
     }


### PR DESCRIPTION
See issue #216.

For consistency, the type and granularity of `latestIdleDuration_` should maybe also be changed, but that is not part of this pull request.