### PR TITLE
Fix crash in HTTPServer::updateTLSCredentials

### DIFF
--- a/proxygen/httpserver/HTTPServer.cpp
+++ b/proxygen/httpserver/HTTPServer.cpp
@@ -245,7 +245,7 @@ int HTTPServer::getListenSocket() const {
 void HTTPServer::updateTLSCredentials() {
   for (auto& bootstrap : bootstrap_) {
     bootstrap.forEachWorker([&](wangle::Acceptor* acceptor) {
-      if (!acceptor) {
+      if (!acceptor || !acceptor->isSSL()) {
         return;
       }
       auto evb = acceptor->getEventBase();
@@ -262,7 +262,7 @@ void HTTPServer::updateTLSCredentials() {
 void HTTPServer::updateTicketSeeds(wangle::TLSTicketKeySeeds seeds) {
   for (auto& bootstrap : bootstrap_) {
     bootstrap.forEachWorker([&](wangle::Acceptor* acceptor) {
-      if (!acceptor) {
+      if (!acceptor || !acceptor->isSSL()) {
         return;
       }
       auto evb = acceptor->getEventBase();

--- a/proxygen/httpserver/tests/HTTPServerTest.cpp
+++ b/proxygen/httpserver/tests/HTTPServerTest.cpp
@@ -418,12 +418,15 @@ TEST(SSL, TestUpdateTLSCredentials) {
   sslCfg.setCertificate(credFile.path().string(), credFile.path().string(), "");
   cfg.sslConfigs.push_back(sslCfg);
 
+  HTTPServer::IPConfig insecureCfg{folly::SocketAddress("127.0.0.1", 0),
+                                   HTTPServer::Protocol::HTTP};
+
   HTTPServerOptions options;
   options.threads = 4;
 
   auto server = std::make_unique<HTTPServer>(std::move(options));
 
-  std::vector<HTTPServer::IPConfig> ips{cfg};
+  std::vector<HTTPServer::IPConfig> ips{cfg, insecureCfg};
   server->bind(ips);
 
   ServerThread st(server.get());


### PR DESCRIPTION
HTTPServer::updateTLSCredentials crashes if there's an acceptor that isn't TLS. (My setup listens on 80 and 443, with only 443 being TLS.)

I modified the existing test so that it crashes without the change to HTTPServer.

(The fix could alternatively go in wangle::Acceptor::resetSSLContextConfigs, or wangle::SSLContextManager::resetSSLContextConfigs.)

Note that I also changed HTTPServer::updateTicketSeeds with a similar fix. Note that I haven't tested that fix or tested to see whether it's a problem.