### PR TITLE
Enable building httpserver/samples/static

### DIFF
--- a/proxygen/configure.ac
+++ b/proxygen/configure.ac
@@ -238,6 +238,7 @@ AC_CONFIG_FILES([Makefile
                  httpserver/samples/echo/Makefile
                  httpserver/samples/proxy/Makefile
                  httpserver/samples/push/Makefile
+                 httpserver/samples/static/Makefile
                  httpserver/tests/Makefile
                  httpclient/Makefile
                  httpclient/samples/curl/Makefile

--- a/proxygen/httpserver/samples/Makefile.am
+++ b/proxygen/httpserver/samples/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = echo proxy push
+SUBDIRS = echo proxy push static

--- a/proxygen/httpserver/samples/static/Makefile.am
+++ b/proxygen/httpserver/samples/static/Makefile.am
@@ -2,9 +2,9 @@ SUBDIRS = .
 
 noinst_PROGRAMS = static_server
 
-echo_server_SOURCES = \
+static_server_SOURCES = \
 	StaticHandler.cpp \
 	StaticServer.cpp
 
-echo_server_LDADD = \
+static_server_LDADD = \
 	../../libproxygenhttpserver.la


### PR DESCRIPTION
An HTTP server sample ("static") was not compiled at all.

Although this is not an important issue, it might be useful from the testing point of view.