### PR TITLE
Added getIOThreadPoolExecutor in HTTPServer to expose IOThreadPoolExecutor to the application

### DIFF
--- a/proxygen/httpserver/HTTPServer.cpp
+++ b/proxygen/httpserver/HTTPServer.cpp
@@ -80,6 +80,7 @@ HTTPServer::HTTPServer(HTTPServerOptions options):
 
 HTTPServer::~HTTPServer() {
   CHECK(!mainEventBase_) << "Forgot to stop() server?";
+  httpServerIOThreadPoolExe.reset();
 }
 
 void HTTPServer::bind(std::vector<IPConfig>&& addrs) {
@@ -121,11 +122,11 @@ void HTTPServer::start(std::function<void()> onSuccess,
   mainEventBase_ = EventBaseManager::get()->getEventBase();
 
   auto accExe = std::make_shared<IOThreadPoolExecutor>(1);
-  auto exe = std::make_shared<IOThreadPoolExecutor>(options_->threads,
+  httpServerIOThreadPoolExe = std::make_shared<IOThreadPoolExecutor>(options_->threads,
     std::make_shared<folly::NamedThreadFactory>("HTTPSrvExec"));
   auto exeObserver = std::make_shared<HandlerCallbacks>(options_);
   // Observer has to be set before bind(), so onServerStart() callbacks run
-  exe->addObserver(exeObserver);
+  httpServerIOThreadPoolExe->addObserver(exeObserver);
 
   try {
     FOR_EACH_RANGE (i, 0, addresses_.size()) {
@@ -148,7 +149,7 @@ void HTTPServer::start(std::function<void()> onSuccess,
         bootstrap_[i].socketConfig.fastOpenQueueSize =
             accConfig.fastOpenQueueSize;
       }
-      bootstrap_[i].group(accExe, exe);
+      bootstrap_[i].group(accExe, httpServerIOThreadPoolExe);
       if (options_->preboundSockets_.size() > 0) {
         bootstrap_[i].bind(std::move(options_->preboundSockets_[i]));
       } else {

--- a/proxygen/httpserver/HTTPServer.h
+++ b/proxygen/httpserver/HTTPServer.h
@@ -17,6 +17,8 @@
 #include <proxygen/lib/http/session/HTTPSession.h>
 #include <thread>
 
+using folly::IOThreadPoolExecutor;
+
 namespace proxygen {
 
 class SignalHandler;
@@ -164,6 +166,10 @@ class HTTPServer final {
    */
   void updateTicketSeeds(wangle::TLSTicketKeySeeds seeds);
 
+  std::shared_ptr<IOThreadPoolExecutor>   getIOThreadPoolExecutor() {
+    return httpServerIOThreadPoolExe;
+  }
+
  private:
   std::shared_ptr<HTTPServerOptions> options_;
 
@@ -187,6 +193,8 @@ class HTTPServer final {
    * Callback for session create/destruction
    */
   HTTPSession::InfoCallback* sessionInfoCb_{nullptr};
+  
+  std::shared_ptr<IOThreadPoolExecutor>   httpServerIOThreadPoolExe{nullptr};
 };
 
 }

--- a/proxygen/httpserver/samples/echo/EchoServer.cpp
+++ b/proxygen/httpserver/samples/echo/EchoServer.cpp
@@ -13,7 +13,6 @@
 #include <folly/portability/Unistd.h>
 #include <proxygen/httpserver/HTTPServer.h>
 #include <proxygen/httpserver/RequestHandlerFactory.h>
-#include <folly/executors/IOThreadPoolExecutor.h>
 
 #include "EchoHandler.h"
 #include "EchoStats.h"
@@ -33,8 +32,6 @@ DEFINE_int32(h2_port, 11002, "Port to listen on with HTTP/2 protocol");
 DEFINE_string(ip, "localhost", "IP/Hostname to bind to");
 DEFINE_int32(threads, 0, "Number of threads to listen on. Numbers <= 0 "
              "will use the number of cores on this machine.");
-
-IOThreadPoolExecutor* iotpe_;
 
 class EchoHandlerFactory : public RequestHandlerFactory {
  public:
@@ -82,25 +79,12 @@ int main(int argc, char* argv[]) {
 
   HTTPServer server(std::move(options));
   server.bind(IPs);
-  iotpe_ = nullptr;
-
-  std::function<void()>  onSuccessCallBack = ([&] () {
-    //iotpe_ = server.getIOThreadPoolExecutor().get();
-    folly::ThreadPoolExecutor::PoolStats stats = server.getIOThreadPoolExecutor()->getPoolStats();
-    std::cout <<"Started http server , io tpe num threads :" << stats.threadCount <<std::endl;
-  });
-
-  std::function<void(std::exception_ptr)>  onFailureCallBack = ([]  (std::exception_ptr) {
-    std::cout <<"Failed to start http server\n";
-  });
-
 
   // Start HTTPServer mainloop in a separate thread
   std::thread t([&] () {
-    server.start(onSuccessCallBack, onFailureCallBack);
+    server.start();
   });
 
   t.join();
-
   return 0;
 }


### PR DESCRIPTION
Hi,
 Added getIOThreadPoolExecutor in HTTPServer so that application get access to IOThreadPoolExecutor, which helps in added observers, fetching thread pool stats etc:

commit ids : 2dc2d625484f05f4a778aa1ab8b05abc95179886 and 
test commit id : 8cf55d2f1ba6ea4d64216ef5284482b3f9bb8974 

Regards
 badari