### PR TITLE
Added getIOThreadPoolExecutor in HTTPServer to expose IOThreadPoolExecutor to the application

### DIFF
--- a/proxygen/httpserver/HTTPServer.h
+++ b/proxygen/httpserver/HTTPServer.h
@@ -17,6 +17,8 @@
 #include <proxygen/lib/http/session/HTTPSession.h>
 #include <thread>
 
+using folly::IOThreadPoolExecutor;
+
 namespace proxygen {
 
 class SignalHandler;
@@ -164,6 +166,10 @@ class HTTPServer final {
    */
   void updateTicketSeeds(wangle::TLSTicketKeySeeds seeds);
 
+  std::shared_ptr<IOThreadPoolExecutor>   getIOThreadPoolExecutor() {
+    return ioExecutor_;
+  }
+
  private:
   std::shared_ptr<HTTPServerOptions> options_;
 
@@ -187,6 +193,8 @@ class HTTPServer final {
    * Callback for session create/destruction
    */
   HTTPSession::InfoCallback* sessionInfoCb_{nullptr};
+  
+  std::shared_ptr<IOThreadPoolExecutor>   ioExecutor_{nullptr};
 };
 
 }


### PR DESCRIPTION
Hi,
Added getIOThreadPoolExecutor in HTTPServer so that application get access to IOThreadPoolExecutor, which helps in added observers, fetching thread pool stats etc:

Incorporated review comments from : https://github.com/facebook/proxygen/pull/228

regards
 badari