### PR TITLE
Build folly and wangle as static libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ server. Try `cd`ing to the directory containing the echo server at
 liner:
 
 <code>
-g++ -std=c++14 -o my_echo EchoServer.cpp EchoHandler.cpp -lproxygenhttpserver -lfolly -lglog -lgflags -pthread
+g++ -std=c++14 -o my_echo EchoServer.cpp EchoHandler.cpp -lproxygenhttpserver -lglog -lgflags -pthread
 </code>
 
 After running `./my_echo`, we can verify it works using curl in a different terminal:

--- a/build/fbcode_builder/fbcode_builder.py
+++ b/build/fbcode_builder/fbcode_builder.py
@@ -196,6 +196,7 @@ class FBCodeBuilder(object):
             'libevent-dev',
             'libgflags-dev',
             'libgoogle-glog-dev',
+            'libiberty-dev',
             'libkrb5-dev',
             'libpcre3-dev',
             'libpthread-stubs0-dev',

--- a/proxygen/configure.ac
+++ b/proxygen/configure.ac
@@ -208,7 +208,7 @@ if test x"$HAVE_GPERF" != x"yes"; then
 fi
 
 LIBS="$LIBS $BOOST_LDFLAGS -lpthread -pthread -lfolly -lglog"
-LIBS="$LIBS -ldouble-conversion -lboost_system -lboost_thread"
+LIBS="$LIBS -ldouble-conversion -lboost_system -lboost_thread -ldl -liberty -lboost_regex -lboost_filesystem -lboost_program_options -lboost_context -lsodium"
 
 AM_CONDITIONAL([HAVE_STD_THREAD], [test "$ac_cv_header_features" = "yes"])
 AM_CONDITIONAL([HAVE_X86_64], [test "$build_cpu" = "x86_64"])

--- a/proxygen/deps.sh
+++ b/proxygen/deps.sh
@@ -102,7 +102,6 @@ then
   fi
 fi
 
-
 # Get folly
 if [ ! -e folly/folly ]; then
     echo "Cloning folly"
@@ -115,7 +114,7 @@ git checkout "$folly_rev"
 # Build folly
 mkdir -p _build
 cd _build
-cmake configure .. -DBUILD_SHARED_LIBS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+cmake configure .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON
 make -j$JOBS
 sudo make install
 
@@ -153,7 +152,7 @@ git checkout "$wangle_rev"
 # Build wangle
 mkdir -p _build
 cd _build
-cmake configure ../wangle -DBUILD_SHARED_LIBS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+cmake configure ../wangle -DCMAKE_POSITION_INDEPENDENT_CODE=ON
 make -j$JOBS
 sudo make install
 

--- a/proxygen/deps.sh
+++ b/proxygen/deps.sh
@@ -43,7 +43,6 @@ sudo apt-get install -yq \
     libcap-dev \
     gperf \
     autoconf-archive \
-    libiberty-dev \
     libevent-dev \
     libtool \
     libboost-all-dev \

--- a/proxygen/deps.sh
+++ b/proxygen/deps.sh
@@ -43,6 +43,7 @@ sudo apt-get install -yq \
     libcap-dev \
     gperf \
     autoconf-archive \
+    libiberty-dev \
     libevent-dev \
     libtool \
     libboost-all-dev \


### PR DESCRIPTION
Per the comments in #225, build folly and wangle as static libraries.

I added zlib1g-dev as a dependency as it's required and not installed on the base debian image. (I'm assuming it is installed on ubuntu.)

The CMAKE_POSITION_INDEPENDANT_CODE flag is still required as proxygen creates its own shared objects. Per the 'no stable ABI' argument, perhaps it shouldn't and I believe that flag could be removed if and when that change is made.