### PR TITLE
add transport stat ability for every handler

### DIFF
--- a/proxygen/httpserver/HTTPServerAcceptor.cpp
+++ b/proxygen/httpserver/HTTPServerAcceptor.cpp
@@ -105,13 +105,24 @@ HTTPTransactionHandler* HTTPServerAcceptor::newHandler(
   msg->setClientAddress(clientAddr);
   msg->setDstAddress(vipAddr);
 
+
   // Create filters chain
+  std::vector<RequestHandler*> rhv;
+
   RequestHandler* h = nullptr;
   for (auto& factory: handlerFactories_) {
     h = factory->onRequest(h, msg);
+    rhv.emplace_back( h );
   }
 
-  return new RequestHandlerAdaptor(h);
+  RequestHandlerAdaptor* p = new RequestHandlerAdaptor(h);
+
+  for( auto rh : rhv )
+  {
+      rh->setTransportStatProvider( p );
+  }
+  return p;
+
 }
 
 void HTTPServerAcceptor::onNewConnection(

--- a/proxygen/httpserver/RequestHandler.h
+++ b/proxygen/httpserver/RequestHandler.h
@@ -10,11 +10,28 @@
 #pragma once
 
 #include <proxygen/lib/http/session/HTTPTransaction.h>
+#include <proxygen/lib/utils/Time.h>
 
 namespace proxygen {
 
 class ResponseHandler;
 class ExMessageHandler;
+
+
+class TransportStatProvider {
+public:
+	struct TransportStat_t
+	{
+	    uint64_t   recv_head_bytes{0}; 
+	    uint64_t   recv_body_bytes{0}; 
+	    uint64_t   send_head_bytes{0}; 
+	    uint64_t   send_body_bytes{0};
+	    TimePoint  start_time;
+	    std::chrono::microseconds duration;
+	};
+  virtual const TransportStat_t& get_stat( ) noexcept  = 0;
+};
+
 
 /**
  * Interface to be implemented by objects that handle requests from
@@ -23,6 +40,8 @@ class ExMessageHandler;
  */
 class RequestHandler {
  public:
+  
+
   /**
    * Saves the downstream handle with itself. Implementations of this
    * interface should use downstream_ to send back response.
@@ -98,6 +117,10 @@ class RequestHandler {
     return downstream_;
   }
 
+  virtual void setTransportStatProvider( TransportStatProvider* p ) noexcept {
+	statProvider_ = p;
+  }
+
   virtual ~RequestHandler() {}
 
  protected:
@@ -106,6 +129,8 @@ class RequestHandler {
    * the response in your RequestHandler.
    */
   ResponseHandler* downstream_{nullptr};
+
+  TransportStatProvider* statProvider_{nullptr};
 };
 
 }


### PR DESCRIPTION
For User defined handler, there is no way to touch HTTPTransaction & RequestHandlerAdaptor directly, all is wrapped by author, so it is a little 
annoying thing that we cannot make an access log like the ngx_http_log_module does, because we cannot touch HTTPTransaction from user defined handler, and so cannot get the head or body bytes received from client, and also cannot get the head or body bytes sent to client easily.

Here, I add a TransactionStatProvider interface to RequestHandlerAdapter, and assign this interface to all handler while the handler is initializing. This TransactionStatProvider will store bytes receive from or sent to client, and the time point when request arrived.
With this patch, in our handler, we can easily add the functionality to retrieve or even log the transaction stat information.
