### PR TITLE
Fix misspelling of "fallthrough".

### DIFF
--- a/proxygen/external/http_parser/http_parser_cpp.cpp
+++ b/proxygen/external/http_parser/http_parser_cpp.cpp
@@ -2365,7 +2365,7 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
       case s_req_server_with_at:
         found_at = 1;
 
-      /* FALLTROUGH */
+      /* FALLTHROUGH */
       case s_req_server:
         uf = UF_HOST;
         break;


### PR DESCRIPTION
"FALLTHROUGH" is misspelled. Because of that, if you set the -Wextra or -Wimplicit-fallthrough flag when compiling, the compiler gives a warning message about an implicit fallthrough.