### PR TITLE
Follow-up "Rename RequestWorker -> RequestWorkerThread"

### DIFF
--- a/proxygen/lib/CMakeLists.txt
+++ b/proxygen/lib/CMakeLists.txt
@@ -139,7 +139,7 @@ add_library(
     http/structuredheaders/StructuredHeadersEncoder.cpp
     http/structuredheaders/StructuredHeadersUtilities.cpp
     http/Window.cpp
-    services/RequestWorker.cpp
+    services/RequestWorkerThread.cpp
     services/Service.cpp
     services/WorkerThread.cpp
     utils/AsyncTimeoutSet.cpp


### PR DESCRIPTION
This commit fixes the CMake build after renaming RequestWorker to RequestWorkerThread in d9741965829412d445d125335f31d17ffe84e372.