### PR TITLE
report the actual ProxygenError instead of Write Error always

### DIFF
--- a/proxygen/httpserver/RequestHandlerAdaptor.cpp
+++ b/proxygen/httpserver/RequestHandlerAdaptor.cpp
@@ -118,7 +118,7 @@ void RequestHandlerAdaptor::onError(const HTTPException& error) noexcept {
     }
 
   } else {
-    setError(kErrorWrite);
+    setError(error.hasProxygenError() ? error.getProxygenError() : kErrorWrite);
   }
 
   // Wait for detachTransaction to clean up


### PR DESCRIPTION
Summary:
this should help services depend on proxygen know more detail about the errors
for example, people may want to do some special handling of specific errors like "StreamAbort, code=CANCEL" which is triggered by a client side cancel and doesn't really sound like an error.

Differential Revision: D15819189

