### PR TITLE
Re-sync with internal repository

### DIFF
--- a/build/deps/github_hashes/facebookincubator/fizz-rev.txt
+++ b/build/deps/github_hashes/facebookincubator/fizz-rev.txt
@@ -1,0 +1,1 @@
+Subproject commit 79291a088867c60cb92e2cb7c2c57b5523b0471b

--- a/build/deps/github_hashes/facebookincubator/mvfst-rev.txt
+++ b/build/deps/github_hashes/facebookincubator/mvfst-rev.txt
@@ -1,0 +1,1 @@
+Subproject commit 88c14a9475b2dcf652cf142f041de58fc8921897


### PR DESCRIPTION
The internal and external repositories are out of sync. This attempts to brings them back in sync by patching the GitHub repository. Please carefully review this patch. You must disable ShipIt for your project in order to merge this pull request. DO NOT IMPORT this pull request. Instead, merge it directly on GitHub using the MERGE BUTTON. Re-enable ShipIt after merging.