### PR TITLE
cmake: fix Python and gperf detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,12 +25,12 @@ file(MAKE_DIRECTORY ${PROXYGEN_GENERATED_ROOT})
 
 # Build-time program requirements.
 find_program(PROXYGEN_PYTHON python)
-if(PROXYGEN_PYTHON-NOTFOUND)
+if(NOT PROXYGEN_PYTHON)
     message(FATAL_ERROR "python is required for the proxygen build")
 endif()
 
 find_program(PROXYGEN_GPERF gperf)
-if(PROXYGEN_GPERF-NOTFOUND)
+if(NOT PROXYGEN_GPERF)
     message(FATAL_ERROR "gperf is required for the proxygen build")
 endif()
 


### PR DESCRIPTION
`find_program()` sets the _value_ of the first parameter (`<VAR>`) to `<VAR>-NOTFOUND` in case the specified program can not be found.

No variables with name `<VAR>-NOTFOUND` will be created.

The if statement of CMake evaluates values ending with -NOTFOUND as False:

> False if the constant is 0, OFF, NO, FALSE, N, IGNORE, NOTFOUND, the empty string, or ends in the suffix -NOTFOUND.