### PR TITLE
Readd GFlags portability header to TestMain

### DIFF
--- a/proxygen/lib/test/TestMain.cpp
+++ b/proxygen/lib/test/TestMain.cpp
@@ -8,6 +8,7 @@
  *
  */
 // Use this main function in gtest unit tests to enable glog
+#include <folly/portability/GFlags.h>
 #include <folly/portability/GTest.h>
 #include <glog/logging.h>
 


### PR DESCRIPTION
Commit 3842e216ca718c814a40fe948e6a839513de1ef2 removed this header as it was considered unused.

```
proxygen/lib/test/TestMain.cpp:16:3: error: ‘gflags’ has not been declared
   16 |   gflags::ParseCommandLineFlags(&argc, &argv, true);
      |   ^~~~~~
```