### PR TITLE
Build with g++ 7.4.0

### DIFF
--- a/proxygen/lib/http/session/test/HQSessionTestCommon.h
+++ b/proxygen/lib/http/session/test/HQSessionTestCommon.h
@@ -156,6 +156,7 @@ class HQSessionTest
         .rttvar = std::chrono::microseconds(0),
         .lrtt = std::chrono::microseconds(0),
         .mrtt = std::chrono::microseconds(0),
+        .mss = quic::kDefaultUDPSendPacketLen,
         .writableBytes = 0,
         .congestionWindow = 1500,
         .pacingBurstSize = 0,


### PR DESCRIPTION
When building with  `g++ (Ubuntu/Linaro 7.4.0-1ubuntu1~18.04.1)` 7.4.0 the "c" style initialisation needs to have all fields populated as it fails to compile otherwise (` sorry, unimplemented: non-trivial designated initializers not supported`).

The alternative, if adding missing field is not desired, is to remove `.` dots, and ` =` ->  `:` change equals to colon.