### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ the dependencies and `proxygen`. You can run the tests manually with `cd _build/
 Then run `./install.sh` to install it. You can remove the temporary build directory (`_build`) and `./build.sh && ./install.sh`
 to rebase the dependencies, and then rebuild and reinstall `proxygen`.
 
+##### Package Managers
+
+You can download and install proxygen using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install proxygen
+
+The proxygen port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ##### Other Platforms
 
 If you are running on another platform, you may need to install several


### PR DESCRIPTION
proxygen is available as a port in vcpkg, a C++ library manager that simplifies installation for proxygen and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build proxygen, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/proxygen/portfile.cmake). We try to keep the library maintained as close as possible to the original library.