### PR TITLE
Remove sudo from install.sh

### DIFF
--- a/proxygen/install.sh
+++ b/proxygen/install.sh
@@ -18,9 +18,9 @@ cd "$(dirname "$0")"
 
 cd _build
 # Uninstall is expected to fail the first time
-sudo make uninstall || true
-sudo make install
+make uninstall || true
+make install
 
 # Make sure the libraries are available
 # Linux only
-sudo /sbin/ldconfig || true
+/sbin/ldconfig || true


### PR DESCRIPTION
Sometimes there is not sudo and install.sh fails:  bash: sudo: command not found

This change removes sudo from the script and lets the user
decide whether to run with sudo or not.

CC: @lnicco 