### PR TITLE
GoogleTest v1.10 compatibility

### DIFF
--- a/build/fbcode_builder/manifests/proxygen
+++ b/build/fbcode_builder/manifests/proxygen
@@ -32,7 +32,7 @@ wangle
 mvfst
 
 [dependencies.test=on]
-googletest_1_8
+googletest
 
 [shipit.pathmap]
 fbcode/proxygen/public_tld = .

--- a/build/fbcode_builder/specs/gmock.py
+++ b/build/fbcode_builder/specs/gmock.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 
 
 def fbcode_builder_spec(builder):
-    builder.add_option('google/googletest:git_hash', 'release-1.8.1')
+    builder.add_option('google/googletest:git_hash', 'release-1.10.0')
     builder.add_option(
         'google/googletest:cmake_defines',
         {

--- a/cmake/ProxygenTest.cmake
+++ b/cmake/ProxygenTest.cmake
@@ -7,8 +7,8 @@
 option(BUILD_TESTS  "Enable tests" OFF)
 include(CTest)
 if(BUILD_TESTS)
-  find_package(GMock 1.8.0 MODULE REQUIRED)
-  find_package(GTest 1.8.0 MODULE REQUIRED)
+  find_package(GMock 1.10.0 MODULE REQUIRED)
+  find_package(GTest 1.10.0 MODULE REQUIRED)
 endif()
 
 function(proxygen_add_test)
@@ -29,7 +29,7 @@ function(proxygen_add_test)
       set(PROXYGEN_TEST_SOURCES "${PROXYGEN_TEST_TARGET}.cpp")
     endif()
 
-    add_executable(${PROXYGEN_TEST_TARGET} 
+    add_executable(${PROXYGEN_TEST_TARGET}
       "${PROXYGEN_TEST_SOURCES}"
     )
 

--- a/proxygen/build.sh
+++ b/proxygen/build.sh
@@ -162,7 +162,7 @@ function setup_googletest() {
   fi
   cd "$GTEST_DIR"
   git fetch --tags
-  git checkout release-1.8.0
+  git checkout release-1.10.0
   echo -e "${COLOR_GREEN}Building googletest ${COLOR_OFF}"
   mkdir -p "$GTEST_BUILD_DIR"
   cd "$GTEST_BUILD_DIR" || exit

--- a/proxygen/httpserver/Mocks.h
+++ b/proxygen/httpserver/Mocks.h
@@ -38,12 +38,8 @@ class MockResponseHandler : public ResponseHandler {
   MOCK_METHOD(void, refreshTimeout, (), (noexcept));
   MOCK_METHOD(void, pauseIngress, (), (noexcept));
   MOCK_METHOD(void, resumeIngress, (), (noexcept));
-  GMOCK_METHOD1_(
-      ,
-      noexcept,
-      ,
-      newPushedResponse,
-      folly::Expected<ResponseHandler*, ProxygenError>(PushHandler*));
+  MOCK_METHOD((folly::Expected<ResponseHandler*, ProxygenError>),
+              newPushedResponse, (PushHandler*), (noexcept));
 
   MOCK_CONST_METHOD1(getCurrentTransportInfo, void(wangle::TransportInfo*));
 #ifdef __clang__

--- a/proxygen/httpserver/Mocks.h
+++ b/proxygen/httpserver/Mocks.h
@@ -31,13 +31,13 @@ class MockResponseHandler : public ResponseHandler {
   MOCK_METHOD(void, sendHeaders, (HTTPMessage&), (noexcept));
   MOCK_METHOD(void, sendChunkHeader, (size_t), (noexcept));
   MOCK_METHOD(void, sendBody, (std::shared_ptr<folly::IOBuf>), (noexcept));
-  GMOCK_METHOD0_(, noexcept, , sendChunkTerminator, void());
+  MOCK_METHOD(void, sendChunkTerminator, (), (noexcept));
   MOCK_METHOD(void, sendTrailers, (const HTTPHeaders&), (noexcept));
-  GMOCK_METHOD0_(, noexcept, , sendEOM, void());
-  GMOCK_METHOD0_(, noexcept, , sendAbort, void());
-  GMOCK_METHOD0_(, noexcept, , refreshTimeout, void());
-  GMOCK_METHOD0_(, noexcept, , pauseIngress, void());
-  GMOCK_METHOD0_(, noexcept, , resumeIngress, void());
+  MOCK_METHOD(void, sendEOM, (), (noexcept));
+  MOCK_METHOD(void, sendAbort, (), (noexcept));
+  MOCK_METHOD(void, refreshTimeout, (), (noexcept));
+  MOCK_METHOD(void, pauseIngress, (), (noexcept));
+  MOCK_METHOD(void, resumeIngress, (), (noexcept));
   GMOCK_METHOD1_(
       ,
       noexcept,
@@ -77,13 +77,13 @@ class MockRequestHandler : public RequestHandler {
   MOCK_METHOD(void, onRequest, (std::shared_ptr<HTTPMessage>), (noexcept));
   MOCK_METHOD(void, onBody, (std::shared_ptr<folly::IOBuf>), (noexcept));
   MOCK_METHOD(void, onUpgrade, (UpgradeProtocol), (noexcept));
-  GMOCK_METHOD0_(, noexcept, , onEOM, void());
-  GMOCK_METHOD0_(, noexcept, , requestComplete, void());
+  MOCK_METHOD(void, onEOM, (), (noexcept));
+  MOCK_METHOD(void, requestComplete, (), (noexcept));
   MOCK_METHOD(void, onError, (ProxygenError), (noexcept));
   MOCK_METHOD(void, onGoaway, (ErrorCode), (noexcept));
-  GMOCK_METHOD0_(, noexcept, , onEgressPaused, void());
-  GMOCK_METHOD0_(, noexcept, , onEgressResumed, void());
-  GMOCK_METHOD0_(, noexcept, , canHandleExpect, bool());
+  MOCK_METHOD(void, onEgressPaused, (), (noexcept));
+  MOCK_METHOD(void, onEgressResumed, (), (noexcept));
+  MOCK_METHOD(bool, canHandleExpect, (), (noexcept));
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif

--- a/proxygen/httpserver/Mocks.h
+++ b/proxygen/httpserver/Mocks.h
@@ -28,11 +28,11 @@ class MockResponseHandler : public ResponseHandler {
 #pragma clang diagnostic ignored "-Winconsistent-missing-override"
 #endif
 #endif
-  GMOCK_METHOD1_(, noexcept, , sendHeaders, void(HTTPMessage&));
-  GMOCK_METHOD1_(, noexcept, , sendChunkHeader, void(size_t));
-  GMOCK_METHOD1_(, noexcept, , sendBody, void(std::shared_ptr<folly::IOBuf>));
+  MOCK_METHOD(void, sendHeaders, (HTTPMessage&), (noexcept));
+  MOCK_METHOD(void, sendChunkHeader, (size_t), (noexcept));
+  MOCK_METHOD(void, sendBody, (std::shared_ptr<folly::IOBuf>), (noexcept));
   GMOCK_METHOD0_(, noexcept, , sendChunkTerminator, void());
-  GMOCK_METHOD1_(, noexcept, , sendTrailers, void(const HTTPHeaders&));
+  MOCK_METHOD(void, sendTrailers, (const HTTPHeaders&), (noexcept));
   GMOCK_METHOD0_(, noexcept, , sendEOM, void());
   GMOCK_METHOD0_(, noexcept, , sendAbort, void());
   GMOCK_METHOD0_(, noexcept, , refreshTimeout, void());
@@ -73,14 +73,14 @@ class MockRequestHandler : public RequestHandler {
 #pragma clang diagnostic ignored "-Winconsistent-missing-override"
 #endif
 #endif
-  GMOCK_METHOD1_(, noexcept, , setResponseHandler, void(ResponseHandler*));
-  GMOCK_METHOD1_(, noexcept, , onRequest, void(std::shared_ptr<HTTPMessage>));
-  GMOCK_METHOD1_(, noexcept, , onBody, void(std::shared_ptr<folly::IOBuf>));
-  GMOCK_METHOD1_(, noexcept, , onUpgrade, void(UpgradeProtocol));
+  MOCK_METHOD(void, setResponseHandler, (ResponseHandler*), (noexcept));
+  MOCK_METHOD(void, onRequest, (std::shared_ptr<HTTPMessage>), (noexcept));
+  MOCK_METHOD(void, onBody, (std::shared_ptr<folly::IOBuf>), (noexcept));
+  MOCK_METHOD(void, onUpgrade, (UpgradeProtocol), (noexcept));
   GMOCK_METHOD0_(, noexcept, , onEOM, void());
   GMOCK_METHOD0_(, noexcept, , requestComplete, void());
-  GMOCK_METHOD1_(, noexcept, , onError, void(ProxygenError));
-  GMOCK_METHOD1_(, noexcept, , onGoaway, void(ErrorCode));
+  MOCK_METHOD(void, onError, (ProxygenError), (noexcept));
+  MOCK_METHOD(void, onGoaway, (ErrorCode), (noexcept));
   GMOCK_METHOD0_(, noexcept, , onEgressPaused, void());
   GMOCK_METHOD0_(, noexcept, , onEgressResumed, void());
   GMOCK_METHOD0_(, noexcept, , canHandleExpect, bool());

--- a/proxygen/lib/http/session/test/ByteEventTrackerTest.cpp
+++ b/proxygen/lib/http/session/test/ByteEventTrackerTest.cpp
@@ -23,7 +23,7 @@ class MockByteEventTrackerCallback : public ByteEventTracker::Callback {
   MOCK_METHOD(void, onPingReplyLatency, (int64_t), (noexcept));
   GMOCK_METHOD1_(
       , noexcept, , onTxnByteEventWrittenToBuf, void(const ByteEvent&));
-  GMOCK_METHOD0_(, noexcept, , onDeleteTxnByteEvent, void());
+  MOCK_METHOD(void, onDeleteTxnByteEvent, (), (noexcept));
 };
 
 class ByteEventTrackerTest : public Test {

--- a/proxygen/lib/http/session/test/ByteEventTrackerTest.cpp
+++ b/proxygen/lib/http/session/test/ByteEventTrackerTest.cpp
@@ -21,8 +21,7 @@ using namespace proxygen;
 class MockByteEventTrackerCallback : public ByteEventTracker::Callback {
  public:
   MOCK_METHOD(void, onPingReplyLatency, (int64_t), (noexcept));
-  GMOCK_METHOD1_(
-      , noexcept, , onTxnByteEventWrittenToBuf, void(const ByteEvent&));
+  MOCK_METHOD(void, onTxnByteEventWrittenToBuf, (const ByteEvent&), (noexcept));
   MOCK_METHOD(void, onDeleteTxnByteEvent, (), (noexcept));
 };
 

--- a/proxygen/lib/http/session/test/ByteEventTrackerTest.cpp
+++ b/proxygen/lib/http/session/test/ByteEventTrackerTest.cpp
@@ -20,7 +20,7 @@ using namespace proxygen;
 
 class MockByteEventTrackerCallback : public ByteEventTracker::Callback {
  public:
-  GMOCK_METHOD1_(, noexcept, , onPingReplyLatency, void(int64_t));
+  MOCK_METHOD(void, onPingReplyLatency, (int64_t), (noexcept));
   GMOCK_METHOD1_(
       , noexcept, , onTxnByteEventWrittenToBuf, void(const ByteEvent&));
   GMOCK_METHOD0_(, noexcept, , onDeleteTxnByteEvent, void());

--- a/proxygen/lib/http/session/test/HQSessionMocks.h
+++ b/proxygen/lib/http/session/test/HQSessionMocks.h
@@ -412,11 +412,8 @@ class MockHQSession : public HQSession {
 
   MOCK_METHOD2(setupOnHeadersComplete, void(HTTPTransaction*, HTTPMessage*));
 
-  GMOCK_METHOD1_(,
-                 noexcept,
-                 ,
-                 onConnectionErrorHandler,
-                 void(std::pair<quic::QuicErrorCode, std::string> error));
+  MOCK_METHOD(void, onConnectionErrorHandler,
+              (std::pair<quic::QuicErrorCode, std::string> error), (noexcept));
 
   MOCK_METHOD1(newTransaction, HTTPTransaction*(HTTPTransaction::Handler*));
 

--- a/proxygen/lib/http/session/test/HTTPSessionMocks.h
+++ b/proxygen/lib/http/session/test/HTTPSessionMocks.h
@@ -16,10 +16,6 @@
 #include <proxygen/lib/http/session/HTTPSessionStats.h>
 #include <proxygen/lib/http/session/HTTPTransaction.h>
 
-#define GMOCK_NOEXCEPT_METHOD0(m, F) GMOCK_METHOD0_(, noexcept, , m, F)
-#define GMOCK_NOEXCEPT_METHOD1(m, F) GMOCK_METHOD1_(, noexcept, , m, F)
-#define GMOCK_NOEXCEPT_METHOD2(m, F) GMOCK_METHOD2_(, noexcept, , m, F)
-
 namespace proxygen {
 
 class HTTPHandlerBase {
@@ -153,63 +149,61 @@ class MockHTTPHandler
       : HTTPHandlerBase(&txn, msg) {
   }
 
-  GMOCK_NOEXCEPT_METHOD1(setTransaction, void(HTTPTransaction* txn));
-
-  GMOCK_NOEXCEPT_METHOD0(detachTransaction, void());
+  MOCK_METHOD(void, setTransaction, (HTTPTransaction* txn), (noexcept));
+  MOCK_METHOD(void, detachTransaction, (), (noexcept));
 
   void onHeadersComplete(std::unique_ptr<HTTPMessage> msg) noexcept override {
     onHeadersComplete(std::shared_ptr<HTTPMessage>(msg.release()));
   }
 
-  GMOCK_NOEXCEPT_METHOD1(onHeadersComplete,
-                         void(std::shared_ptr<HTTPMessage> msg));
+  MOCK_METHOD(void, onHeadersComplete, (std::shared_ptr<HTTPMessage> msg),
+              (noexcept));
 
   void onBody(std::unique_ptr<folly::IOBuf> chain) noexcept override {
     onBody(std::shared_ptr<folly::IOBuf>(chain.release()));
   }
-  GMOCK_NOEXCEPT_METHOD1(onBody, void(std::shared_ptr<folly::IOBuf> chain));
+  MOCK_METHOD(void, onBody, (std::shared_ptr<folly::IOBuf> chain), (noexcept));
 
   void onBodyWithOffset(uint64_t bodyOffset,
                         std::unique_ptr<folly::IOBuf> chain) noexcept override {
     onBodyWithOffset(bodyOffset,
                      std::shared_ptr<folly::IOBuf>(chain.release()));
   }
-  GMOCK_NOEXCEPT_METHOD2(onBodyWithOffset,
-                         void(uint64_t bodyOffset,
-                              std::shared_ptr<folly::IOBuf> chain));
+  MOCK_METHOD(void, onBodyWithOffset, (uint64_t bodyOffset,
+              std::shared_ptr<folly::IOBuf> chain), (noexcept));
 
-  GMOCK_NOEXCEPT_METHOD1(onChunkHeader, void(size_t length));
+  MOCK_METHOD(void, onChunkHeader, (size_t length), (noexcept));
 
-  GMOCK_NOEXCEPT_METHOD0(onChunkComplete, void());
+  MOCK_METHOD(void, onChunkComplete, (), (noexcept));
 
   void onTrailers(std::unique_ptr<HTTPHeaders> trailers) noexcept override {
     onTrailers(std::shared_ptr<HTTPHeaders>(trailers.release()));
   }
 
-  GMOCK_NOEXCEPT_METHOD1(onTrailers,
-                         void(std::shared_ptr<HTTPHeaders> trailers));
+  MOCK_METHOD(void, onTrailers, (std::shared_ptr<HTTPHeaders> trailers),
+              (noexcept));
 
-  GMOCK_NOEXCEPT_METHOD0(onEOM, void());
+  MOCK_METHOD(void, onEOM, (), (noexcept));
 
-  GMOCK_NOEXCEPT_METHOD1(onUpgrade, void(UpgradeProtocol protocol));
+  MOCK_METHOD(void, onUpgrade, (UpgradeProtocol protocol), (noexcept));
 
-  GMOCK_NOEXCEPT_METHOD1(onError, void(const HTTPException& error));
+  MOCK_METHOD(void, onError, (const HTTPException& error), (noexcept));
 
-  GMOCK_NOEXCEPT_METHOD1(onGoaway, void(ErrorCode));
+  MOCK_METHOD(void, onGoaway, (ErrorCode), (noexcept));
 
-  GMOCK_NOEXCEPT_METHOD0(onEgressPaused, void());
+  MOCK_METHOD(void, onEgressPaused, (), (noexcept));
 
-  GMOCK_NOEXCEPT_METHOD0(onEgressResumed, void());
+  MOCK_METHOD(void, onEgressResumed, (), (noexcept));
 
-  GMOCK_NOEXCEPT_METHOD1(onPushedTransaction, void(HTTPTransaction*));
+  MOCK_METHOD(void, onPushedTransaction, (HTTPTransaction*), (noexcept));
 
-  GMOCK_NOEXCEPT_METHOD1(onExTransaction, void(HTTPTransaction*));
+  MOCK_METHOD(void, onExTransaction, (HTTPTransaction*), (noexcept));
 
-  GMOCK_NOEXCEPT_METHOD1(onBodySkipped, void(uint64_t));
+  MOCK_METHOD(void, onBodySkipped, (uint64_t), (noexcept));
 
-  GMOCK_NOEXCEPT_METHOD1(onBodyRejected, void(uint64_t));
+  MOCK_METHOD(void, onBodyRejected, (uint64_t), (noexcept));
 
-  GMOCK_NOEXCEPT_METHOD1(traceEventAvailable, void(TraceEvent));
+  MOCK_METHOD(void, traceEventAvailable, (TraceEvent), (noexcept));
 
   void expectTransaction(std::function<void(HTTPTransaction* txn)> callback) {
     EXPECT_CALL(*this, setTransaction(testing::_))
@@ -369,21 +363,21 @@ class MockHTTPPushHandler
       : HTTPHandlerBase(&txn, msg) {
   }
 
-  GMOCK_NOEXCEPT_METHOD1(setTransaction, void(HTTPTransaction* txn));
+  MOCK_METHOD(void, setTransaction, (HTTPTransaction* txn), (noexcept));
 
-  GMOCK_NOEXCEPT_METHOD0(detachTransaction, void());
+  MOCK_METHOD(void, detachTransaction, (), (noexcept));
 
-  GMOCK_NOEXCEPT_METHOD1(onError, void(const HTTPException& error));
+  MOCK_METHOD(void, onError, (const HTTPException& error), (noexcept));
 
-  GMOCK_NOEXCEPT_METHOD1(onGoaway, void(ErrorCode));
+  MOCK_METHOD(void, onGoaway, (ErrorCode), (noexcept));
 
-  GMOCK_NOEXCEPT_METHOD0(onEgressPaused, void());
+  MOCK_METHOD(void, onEgressPaused, (), (noexcept));
 
-  GMOCK_NOEXCEPT_METHOD0(onEgressResumed, void());
+  MOCK_METHOD(void, onEgressResumed, (), (noexcept));
 
-  GMOCK_NOEXCEPT_METHOD1(onBodySkipped, void(uint64_t));
+  MOCK_METHOD(void, onBodySkipped, (uint64_t), (noexcept));
 
-  GMOCK_NOEXCEPT_METHOD1(onBodyRejected, void(uint64_t));
+  MOCK_METHOD(void, onBodyRejected, (uint64_t), (noexcept));
 
   void sendPushHeaders(const std::string& path,
                        const std::string& host,
@@ -506,13 +500,13 @@ class MockHTTPSessionStats : public DummyHTTPSessionStats {
  public:
   MockHTTPSessionStats() {
   }
-  GMOCK_NOEXCEPT_METHOD0(recordTransactionOpened, void());
-  GMOCK_NOEXCEPT_METHOD0(recordTransactionClosed, void());
-  GMOCK_NOEXCEPT_METHOD1(recordTransactionsServed, void(uint64_t));
-  GMOCK_NOEXCEPT_METHOD0(recordSessionReused, void());
-  GMOCK_NOEXCEPT_METHOD1(recordSessionIdleTime, void(std::chrono::seconds));
-  GMOCK_NOEXCEPT_METHOD0(recordTransactionStalled, void());
-  GMOCK_NOEXCEPT_METHOD0(recordSessionStalled, void());
+  MOCK_METHOD(void, recordTransactionOpened, (), (noexcept));
+  MOCK_METHOD(void, recordTransactionClosed, (), (noexcept));
+  MOCK_METHOD(void, recordTransactionsServed, (uint64_t), (noexcept));
+  MOCK_METHOD(void, recordSessionReused, (), (noexcept));
+  MOCK_METHOD(void, recordSessionIdleTime, (std::chrono::seconds), (noexcept));
+  MOCK_METHOD(void, recordTransactionStalled, (), (noexcept));
+  MOCK_METHOD(void, recordSessionStalled, (), (noexcept));
 };
 
 } // namespace proxygen

--- a/proxygen/lib/http/session/test/HTTPTransactionMocks.h
+++ b/proxygen/lib/http/session/test/HTTPTransactionMocks.h
@@ -28,18 +28,12 @@ class MockHTTPTransactionTransport : public HTTPTransaction::Transport {
   MOCK_METHOD(void, pauseIngress, (HTTPTransaction*), (noexcept));
   MOCK_METHOD(void, resumeIngress, (HTTPTransaction*), (noexcept));
   MOCK_METHOD(void, transactionTimeout, (HTTPTransaction*), (noexcept));
-  GMOCK_METHOD4_(
-      ,
-      noexcept,
-      ,
-      sendHeaders,
-      void(HTTPTransaction*, const HTTPMessage&, HTTPHeaderSize*, bool));
-  GMOCK_METHOD4_(
-      ,
-      noexcept,
-      ,
-      sendBody,
-      size_t(HTTPTransaction*, std::shared_ptr<folly::IOBuf>, bool, bool));
+  MOCK_METHOD(void, sendHeaders,
+              (HTTPTransaction*, const HTTPMessage&, HTTPHeaderSize*, bool),
+              (noexcept));
+  MOCK_METHOD(size_t, sendBody,
+              (HTTPTransaction*, std::shared_ptr<folly::IOBuf>, bool, bool),
+              (noexcept));
 
   size_t sendBody(HTTPTransaction* txn,
                   std::unique_ptr<folly::IOBuf> iob,
@@ -51,57 +45,44 @@ class MockHTTPTransactionTransport : public HTTPTransaction::Transport {
                     trackLastByteFlushed);
   }
 
-  GMOCK_METHOD0_(, , , getHTTPSessionBase, HTTPSessionBase*());
-  GMOCK_METHOD2_(
-      , noexcept, , sendChunkHeader, size_t(HTTPTransaction*, size_t));
+  MOCK_METHOD(HTTPSessionBase*, getHTTPSessionBase, (), ());
+  MOCK_METHOD(size_t, sendChunkHeader, (HTTPTransaction*, size_t), (noexcept));
   MOCK_METHOD(size_t, sendChunkTerminator, (HTTPTransaction*), (noexcept));
-  GMOCK_METHOD2_(
-      , noexcept, , sendEOM, size_t(HTTPTransaction*, const HTTPHeaders*));
-  GMOCK_METHOD2_(, noexcept, , sendAbort, size_t(HTTPTransaction*, ErrorCode));
-  GMOCK_METHOD2_(,
-                 noexcept,
-                 ,
-                 sendPriority,
-                 size_t(HTTPTransaction*, const http2::PriorityUpdate&));
+  MOCK_METHOD(size_t, sendEOM, (HTTPTransaction*, const HTTPHeaders*),
+              (noexcept));
+  MOCK_METHOD(size_t, sendAbort, (HTTPTransaction*, ErrorCode), (noexcept));
+  MOCK_METHOD(size_t, sendPriority,
+              (HTTPTransaction*, const http2::PriorityUpdate&), (noexcept));
   MOCK_METHOD(void, notifyPendingEgress, (), (noexcept));
   MOCK_METHOD(void, detach, (HTTPTransaction*), (noexcept));
-  GMOCK_METHOD2_(
-      , noexcept, , sendWindowUpdate, size_t(HTTPTransaction*, uint32_t));
+  MOCK_METHOD(size_t, sendWindowUpdate, (HTTPTransaction*, uint32_t),
+              (noexcept));
   MOCK_METHOD(void, notifyIngressBodyProcessed, (uint32_t), (noexcept));
   MOCK_METHOD(void, notifyEgressBodyBuffered, (int64_t), (noexcept));
-  GMOCK_METHOD0_(
-      , noexcept, , getLocalAddressNonConst, const folly::SocketAddress&());
-  GMOCK_METHOD3_(,
-                 noexcept,
-                 ,
-                 newPushedTransaction,
-                 HTTPTransaction*(HTTPCodec::StreamID assocStreamId,
-                                  HTTPTransaction::PushHandler* handler,
-                                  ProxygenError* error));
-  GMOCK_METHOD3_(,
-                 noexcept,
-                 ,
-                 newExTransaction,
-                 HTTPTransaction*(HTTPTransaction::Handler* handler,
-                                  HTTPCodec::StreamID controlStream,
-                                  bool unidirectional));
+  MOCK_METHOD(const folly::SocketAddress&, getLocalAddressNonConst, (),
+              (noexcept));
+  MOCK_METHOD(HTTPTransaction*, newPushedTransaction,
+              (HTTPCodec::StreamID assocStreamId,
+               HTTPTransaction::PushHandler* handler,
+               ProxygenError* error), (noexcept));
+  MOCK_METHOD(HTTPTransaction*, newExTransaction,
+              (HTTPTransaction::Handler* handler,
+               HTTPCodec::StreamID controlStream,
+               bool unidirectional), (noexcept));
 
   const folly::SocketAddress& getLocalAddress() const noexcept override {
     return const_cast<MockHTTPTransactionTransport*>(this)
         ->getLocalAddressNonConst();
   }
-  GMOCK_METHOD0_(
-      , noexcept, , getPeerAddressNonConst, const folly::SocketAddress&());
+  MOCK_METHOD(const folly::SocketAddress&, getPeerAddressNonConst, (),
+              (noexcept));
   const folly::SocketAddress& getPeerAddress() const noexcept override {
     return const_cast<MockHTTPTransactionTransport*>(this)
         ->getPeerAddressNonConst();
   }
   MOCK_CONST_METHOD1(describe, void(std::ostream&));
-  GMOCK_METHOD0_(,
-                 noexcept,
-                 ,
-                 getSetupTransportInfoNonConst,
-                 const wangle::TransportInfo&());
+  MOCK_METHOD(const wangle::TransportInfo&, getSetupTransportInfoNonConst, (),
+              (noexcept));
   const wangle::TransportInfo& getSetupTransportInfo() const noexcept override {
     return const_cast<MockHTTPTransactionTransport*>(this)
         ->getSetupTransportInfoNonConst();
@@ -110,8 +91,8 @@ class MockHTTPTransactionTransport : public HTTPTransaction::Transport {
   MOCK_METHOD1(getCurrentTransportInfo, bool(wangle::TransportInfo*));
   MOCK_METHOD1(getFlowControlInfo, void(HTTPTransaction::FlowControlInfo*));
 
-  GMOCK_METHOD0_(
-      , noexcept, , getSessionTypeNonConst, HTTPTransaction::Transport::Type());
+  MOCK_METHOD(HTTPTransaction::Transport::Type, getSessionTypeNonConst, (),
+              (noexcept));
   HTTPTransaction::Transport::Type getSessionType() const noexcept override {
     return const_cast<MockHTTPTransactionTransport*>(this)
         ->getSessionTypeNonConst();
@@ -127,23 +108,14 @@ class MockHTTPTransactionTransport : public HTTPTransaction::Transport {
   MOCK_CONST_METHOD0(getTransport, const folly::AsyncTransport*());
   MOCK_METHOD0(getTransport, folly::AsyncTransport*());
 
-  GMOCK_METHOD1_(,
-                 noexcept,
-                 ,
-                 addWaitingForReplaySafety,
-                 void(folly::AsyncTransport::ReplaySafetyCallback*));
-  GMOCK_METHOD1_(,
-                 noexcept,
-                 ,
-                 removeWaitingForReplaySafety,
-                 void(folly::AsyncTransport::ReplaySafetyCallback*));
+  MOCK_METHOD(void, addWaitingForReplaySafety,
+              (folly::AsyncTransport::ReplaySafetyCallback*), (noexcept));
+  MOCK_METHOD(void, removeWaitingForReplaySafety,
+              (folly::AsyncTransport::ReplaySafetyCallback*), (noexcept));
   MOCK_CONST_METHOD0(needToBlockForReplaySafety, bool());
 
-  GMOCK_METHOD0_(,
-                 noexcept,
-                 ,
-                 getUnderlyingTransportNonConst,
-                 const folly::AsyncTransport*());
+  MOCK_METHOD(const folly::AsyncTransport*, getUnderlyingTransportNonConst, (),
+              (noexcept));
   const folly::AsyncTransport* getUnderlyingTransport() const
       noexcept override {
     return const_cast<MockHTTPTransactionTransport*>(this)
@@ -172,11 +144,8 @@ class MockHTTPTransactionTransport : public HTTPTransaction::Transport {
                folly::Expected<folly::Optional<uint64_t>, ErrorCode>(
                    HTTPTransaction*, uint64_t));
 
-  GMOCK_METHOD0_(,
-                 noexcept,
-                 ,
-                 getConnectionTokenNonConst,
-                 folly::Optional<HTTPTransaction::ConnectionToken>());
+  MOCK_METHOD(folly::Optional<HTTPTransaction::ConnectionToken>,
+              getConnectionTokenNonConst, (), (noexcept));
   folly::Optional<HTTPTransaction::ConnectionToken> getConnectionToken() const
       noexcept override {
     return const_cast<MockHTTPTransactionTransport*>(this)
@@ -364,8 +333,7 @@ class MockHTTPTransactionTransportCallback
   MOCK_METHOD(void, trackedByteEventAck, (const ByteEvent&), (noexcept));
   MOCK_METHOD(void, egressBufferEmpty, (), (noexcept));
   MOCK_METHOD(void, headerBytesGenerated, (HTTPHeaderSize&), (noexcept));
-  GMOCK_METHOD1_(
-      , noexcept, , headerBytesReceived, void(const HTTPHeaderSize&));
+  MOCK_METHOD(void, headerBytesReceived, (const HTTPHeaderSize&), (noexcept));
   MOCK_METHOD(void, bodyBytesGenerated, (size_t), (noexcept));
   MOCK_METHOD(void, bodyBytesReceived, (size_t), (noexcept));
   MOCK_METHOD(void, transportAppRateLimited, (), (noexcept));

--- a/proxygen/lib/http/session/test/HTTPTransactionMocks.h
+++ b/proxygen/lib/http/session/test/HTTPTransactionMocks.h
@@ -63,7 +63,7 @@ class MockHTTPTransactionTransport : public HTTPTransaction::Transport {
                  ,
                  sendPriority,
                  size_t(HTTPTransaction*, const http2::PriorityUpdate&));
-  GMOCK_METHOD0_(, noexcept, , notifyPendingEgress, void());
+  MOCK_METHOD(void, notifyPendingEgress, (), (noexcept));
   MOCK_METHOD(void, detach, (HTTPTransaction*), (noexcept));
   GMOCK_METHOD2_(
       , noexcept, , sendWindowUpdate, size_t(HTTPTransaction*, uint32_t));
@@ -116,7 +116,7 @@ class MockHTTPTransactionTransport : public HTTPTransaction::Transport {
     return const_cast<MockHTTPTransactionTransport*>(this)
         ->getSessionTypeNonConst();
   }
-  GMOCK_METHOD0_(, noexcept, , getCodecNonConst, const HTTPCodec&());
+  MOCK_METHOD(const HTTPCodec&, getCodecNonConst, (), (noexcept));
   const HTTPCodec& getCodec() const noexcept override {
     return const_cast<MockHTTPTransactionTransport*>(this)->getCodecNonConst();
   }
@@ -355,20 +355,20 @@ class MockHTTPTransactionTransportCallback
  public:
   MockHTTPTransactionTransportCallback() {
   }
-  GMOCK_METHOD0_(, noexcept, , firstHeaderByteFlushed, void());
-  GMOCK_METHOD0_(, noexcept, , firstByteFlushed, void());
-  GMOCK_METHOD0_(, noexcept, , trackedByteFlushed, void());
-  GMOCK_METHOD0_(, noexcept, , lastByteFlushed, void());
+  MOCK_METHOD(void, firstHeaderByteFlushed, (), (noexcept));
+  MOCK_METHOD(void, firstByteFlushed, (), (noexcept));
+  MOCK_METHOD(void, trackedByteFlushed, (), (noexcept));
+  MOCK_METHOD(void, lastByteFlushed, (), (noexcept));
   MOCK_METHOD(void, lastByteAcked, (std::chrono::milliseconds), (noexcept));
   MOCK_METHOD(void, trackedByteEventTX, (const ByteEvent&), (noexcept));
   MOCK_METHOD(void, trackedByteEventAck, (const ByteEvent&), (noexcept));
-  GMOCK_METHOD0_(, noexcept, , egressBufferEmpty, void());
+  MOCK_METHOD(void, egressBufferEmpty, (), (noexcept));
   MOCK_METHOD(void, headerBytesGenerated, (HTTPHeaderSize&), (noexcept));
   GMOCK_METHOD1_(
       , noexcept, , headerBytesReceived, void(const HTTPHeaderSize&));
   MOCK_METHOD(void, bodyBytesGenerated, (size_t), (noexcept));
   MOCK_METHOD(void, bodyBytesReceived, (size_t), (noexcept));
-  GMOCK_METHOD0_(, noexcept, , transportAppRateLimited, void());
+  MOCK_METHOD(void, transportAppRateLimited, (), (noexcept));
 };
 
 #if defined(__clang__) && __clang_major__ >= 3 && __clang_minor__ >= 6

--- a/proxygen/lib/http/session/test/HTTPTransactionMocks.h
+++ b/proxygen/lib/http/session/test/HTTPTransactionMocks.h
@@ -25,9 +25,9 @@ class MockHTTPTransactionTransport : public HTTPTransaction::Transport {
     EXPECT_CALL(*this, getCodecNonConst())
         .WillRepeatedly(testing::ReturnRef(mockCodec_));
   }
-  GMOCK_METHOD1_(, noexcept, , pauseIngress, void(HTTPTransaction*));
-  GMOCK_METHOD1_(, noexcept, , resumeIngress, void(HTTPTransaction*));
-  GMOCK_METHOD1_(, noexcept, , transactionTimeout, void(HTTPTransaction*));
+  MOCK_METHOD(void, pauseIngress, (HTTPTransaction*), (noexcept));
+  MOCK_METHOD(void, resumeIngress, (HTTPTransaction*), (noexcept));
+  MOCK_METHOD(void, transactionTimeout, (HTTPTransaction*), (noexcept));
   GMOCK_METHOD4_(
       ,
       noexcept,
@@ -54,7 +54,7 @@ class MockHTTPTransactionTransport : public HTTPTransaction::Transport {
   GMOCK_METHOD0_(, , , getHTTPSessionBase, HTTPSessionBase*());
   GMOCK_METHOD2_(
       , noexcept, , sendChunkHeader, size_t(HTTPTransaction*, size_t));
-  GMOCK_METHOD1_(, noexcept, , sendChunkTerminator, size_t(HTTPTransaction*));
+  MOCK_METHOD(size_t, sendChunkTerminator, (HTTPTransaction*), (noexcept));
   GMOCK_METHOD2_(
       , noexcept, , sendEOM, size_t(HTTPTransaction*, const HTTPHeaders*));
   GMOCK_METHOD2_(, noexcept, , sendAbort, size_t(HTTPTransaction*, ErrorCode));
@@ -64,11 +64,11 @@ class MockHTTPTransactionTransport : public HTTPTransaction::Transport {
                  sendPriority,
                  size_t(HTTPTransaction*, const http2::PriorityUpdate&));
   GMOCK_METHOD0_(, noexcept, , notifyPendingEgress, void());
-  GMOCK_METHOD1_(, noexcept, , detach, void(HTTPTransaction*));
+  MOCK_METHOD(void, detach, (HTTPTransaction*), (noexcept));
   GMOCK_METHOD2_(
       , noexcept, , sendWindowUpdate, size_t(HTTPTransaction*, uint32_t));
-  GMOCK_METHOD1_(, noexcept, , notifyIngressBodyProcessed, void(uint32_t));
-  GMOCK_METHOD1_(, noexcept, , notifyEgressBodyBuffered, void(int64_t));
+  MOCK_METHOD(void, notifyIngressBodyProcessed, (uint32_t), (noexcept));
+  MOCK_METHOD(void, notifyEgressBodyBuffered, (int64_t), (noexcept));
   GMOCK_METHOD0_(
       , noexcept, , getLocalAddressNonConst, const folly::SocketAddress&());
   GMOCK_METHOD3_(,
@@ -359,15 +359,15 @@ class MockHTTPTransactionTransportCallback
   GMOCK_METHOD0_(, noexcept, , firstByteFlushed, void());
   GMOCK_METHOD0_(, noexcept, , trackedByteFlushed, void());
   GMOCK_METHOD0_(, noexcept, , lastByteFlushed, void());
-  GMOCK_METHOD1_(, noexcept, , lastByteAcked, void(std::chrono::milliseconds));
-  GMOCK_METHOD1_(, noexcept, , trackedByteEventTX, void(const ByteEvent&));
-  GMOCK_METHOD1_(, noexcept, , trackedByteEventAck, void(const ByteEvent&));
+  MOCK_METHOD(void, lastByteAcked, (std::chrono::milliseconds), (noexcept));
+  MOCK_METHOD(void, trackedByteEventTX, (const ByteEvent&), (noexcept));
+  MOCK_METHOD(void, trackedByteEventAck, (const ByteEvent&), (noexcept));
   GMOCK_METHOD0_(, noexcept, , egressBufferEmpty, void());
-  GMOCK_METHOD1_(, noexcept, , headerBytesGenerated, void(HTTPHeaderSize&));
+  MOCK_METHOD(void, headerBytesGenerated, (HTTPHeaderSize&), (noexcept));
   GMOCK_METHOD1_(
       , noexcept, , headerBytesReceived, void(const HTTPHeaderSize&));
-  GMOCK_METHOD1_(, noexcept, , bodyBytesGenerated, void(size_t));
-  GMOCK_METHOD1_(, noexcept, , bodyBytesReceived, void(size_t));
+  MOCK_METHOD(void, bodyBytesGenerated, (size_t), (noexcept));
+  MOCK_METHOD(void, bodyBytesReceived, (size_t), (noexcept));
   GMOCK_METHOD0_(, noexcept, , transportAppRateLimited, void());
 };
 

--- a/proxygen/lib/http/session/test/MockByteEventTracker.h
+++ b/proxygen/lib/http/session/test/MockByteEventTracker.h
@@ -25,20 +25,13 @@ class MockByteEventTracker : public ByteEventTracker {
   MOCK_METHOD0(drainByteEvents, size_t());
   MOCK_METHOD2(processByteEvents,
                bool(std::shared_ptr<ByteEventTracker>, uint64_t));
-  GMOCK_METHOD2_(
-      , noexcept, , addTrackedByteEvent, void(HTTPTransaction*, uint64_t));
-  GMOCK_METHOD2_(
-      , noexcept, , addLastByteEvent, void(HTTPTransaction*, uint64_t));
-  GMOCK_METHOD3_(,
-                 noexcept,
-                 ,
-                 addTxByteEvent,
-                 void(uint64_t, ByteEvent::EventType, HTTPTransaction*));
-  GMOCK_METHOD3_(,
-                 noexcept,
-                 ,
-                 addAckByteEvent,
-                 void(uint64_t, ByteEvent::EventType, HTTPTransaction*));
+  MOCK_METHOD(void, addTrackedByteEvent, (HTTPTransaction*, uint64_t),
+              (noexcept));
+  MOCK_METHOD(void, addLastByteEvent, (HTTPTransaction*, uint64_t), (noexcept));
+  MOCK_METHOD(void, addTxByteEvent,
+              (uint64_t, ByteEvent::EventType, HTTPTransaction*), (noexcept));
+  MOCK_METHOD(void, addAckByteEvent,
+              (uint64_t, ByteEvent::EventType, HTTPTransaction*), (noexcept));
   MOCK_METHOD4(preSend, uint64_t(bool*, bool*, bool*, uint64_t));
 
   // passthru to callback implementation functions


### PR DESCRIPTION
This PR replaces all internal `GMOCK_METHOD*_()` macro usage with the well-documented `MOCK_METHOD()`.
That way, proxygen tests can be compiled with GoogleTest v1.10.

`MOCK_METHOD()` requires `GoogleTest >= 1.10.0`, so the change is probably not as easy as I wanted it to be.

I'd be happy to contribute to the rest of Facebook's trinity as well (folly, fizz, wangle), if I could help with the transition.