### PR TITLE
fix for proxygen build in circleci for AIRStore OSS project

### DIFF
--- a/proxygen/CMakeLists.txt
+++ b/proxygen/CMakeLists.txt
@@ -4,6 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+
+if (NOT DEFINED LIB_INSTALL_DIR)
+    set(LIB_INSTALL_DIR "lib")
+endif()
+
 add_subdirectory(external)
 add_subdirectory(lib)
 add_subdirectory(httpserver)

--- a/proxygen/httpclient/samples/curl/CMakeLists.txt
+++ b/proxygen/httpclient/samples/curl/CMakeLists.txt
@@ -3,6 +3,7 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+cmake_minimum_required(VERSION 3.10)
 
 add_library(proxygencurl CurlClient.cpp)
 target_include_directories(
@@ -28,9 +29,8 @@ target_link_libraries(proxygencurl PUBLIC proxygen)
 install(
     TARGETS proxygencurl
     EXPORT proxygen-exports
-    DESTINATION ${LIB_INSTALL_DIR}
-    LIBRARY DESTINATION ${LIB_INSTALL_DIR}
     ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
+    LIBRARY DESTINATION ${LIB_INSTALL_DIR}
 )
 
 add_executable(proxygen_curl CurlClientMain.cpp)

--- a/proxygen/httpclient/samples/curl/CMakeLists.txt
+++ b/proxygen/httpclient/samples/curl/CMakeLists.txt
@@ -29,6 +29,8 @@ install(
     TARGETS proxygencurl
     EXPORT proxygen-exports
     DESTINATION ${LIB_INSTALL_DIR}
+    LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+    ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
 )
 
 add_executable(proxygen_curl CurlClientMain.cpp)

--- a/proxygen/httpclient/samples/curl/CMakeLists.txt
+++ b/proxygen/httpclient/samples/curl/CMakeLists.txt
@@ -5,6 +5,10 @@
 # LICENSE file in the root directory of this source tree.
 cmake_minimum_required(VERSION 3.10)
 
+if (NOT DEFINED LIB_INSTALL_DIR)
+    set(LIB_INSTALL_DIR "lib")
+endif()
+
 add_library(proxygencurl CurlClient.cpp)
 target_include_directories(
     proxygencurl PUBLIC

--- a/proxygen/httpclient/samples/curl/CMakeLists.txt
+++ b/proxygen/httpclient/samples/curl/CMakeLists.txt
@@ -4,10 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-if (NOT DEFINED LIB_INSTALL_DIR)
-    set(LIB_INSTALL_DIR "lib")
-endif()
-
 add_library(proxygencurl CurlClient.cpp)
 target_include_directories(
     proxygencurl PUBLIC

--- a/proxygen/httpclient/samples/curl/CMakeLists.txt
+++ b/proxygen/httpclient/samples/curl/CMakeLists.txt
@@ -3,7 +3,6 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-cmake_minimum_required(VERSION 3.10)
 
 if (NOT DEFINED LIB_INSTALL_DIR)
     set(LIB_INSTALL_DIR "lib")

--- a/proxygen/httpserver/CMakeLists.txt
+++ b/proxygen/httpserver/CMakeLists.txt
@@ -28,12 +28,12 @@ target_link_libraries(
     PUBLIC
         proxygen
 )
+
 install(
     TARGETS proxygenhttpserver
     EXPORT proxygen-exports
-    DESTINATION ${LIB_INSTALL_DIR}
-    LIBRARY DESTINATION ${LIB_INSTALL_DIR}
     ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
+    LIBRARY DESTINATION ${LIB_INSTALL_DIR}
 )
 
 add_executable(proxygen_push

--- a/proxygen/httpserver/CMakeLists.txt
+++ b/proxygen/httpserver/CMakeLists.txt
@@ -4,6 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+if (NOT DEFINED LIB_INSTALL_DIR)
+    set(LIB_INSTALL_DIR "lib")
+endif()
+
 add_library(
     proxygenhttpserver
     RequestHandlerAdaptor.cpp

--- a/proxygen/httpserver/CMakeLists.txt
+++ b/proxygen/httpserver/CMakeLists.txt
@@ -32,6 +32,8 @@ install(
     TARGETS proxygenhttpserver
     EXPORT proxygen-exports
     DESTINATION ${LIB_INSTALL_DIR}
+    LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+    ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
 )
 
 add_executable(proxygen_push

--- a/proxygen/httpserver/CMakeLists.txt
+++ b/proxygen/httpserver/CMakeLists.txt
@@ -4,10 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-if (NOT DEFINED LIB_INSTALL_DIR)
-    set(LIB_INSTALL_DIR "lib")
-endif()
-
 add_library(
     proxygenhttpserver
     RequestHandlerAdaptor.cpp

--- a/proxygen/lib/CMakeLists.txt
+++ b/proxygen/lib/CMakeLists.txt
@@ -265,7 +265,6 @@ install(
 install(
     TARGETS proxygen
     EXPORT proxygen-exports
-    DESTINATION ${LIB_INSTALL_DIR}
     LIBRARY DESTINATION ${LIB_INSTALL_DIR}
     ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
 )

--- a/proxygen/lib/CMakeLists.txt
+++ b/proxygen/lib/CMakeLists.txt
@@ -4,6 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+if (NOT DEFINED LIB_INSTALL_DIR)
+    set(LIB_INSTALL_DIR "lib")
+endif()
+
 file(
     MAKE_DIRECTORY
     ${PROXYGEN_GENERATED_ROOT}/proxygen/lib/http

--- a/proxygen/lib/CMakeLists.txt
+++ b/proxygen/lib/CMakeLists.txt
@@ -4,10 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-if (NOT DEFINED LIB_INSTALL_DIR)
-    set(LIB_INSTALL_DIR "lib")
-endif()
-
 file(
     MAKE_DIRECTORY
     ${PROXYGEN_GENERATED_ROOT}/proxygen/lib/http

--- a/proxygen/lib/CMakeLists.txt
+++ b/proxygen/lib/CMakeLists.txt
@@ -266,6 +266,8 @@ install(
     TARGETS proxygen
     EXPORT proxygen-exports
     DESTINATION ${LIB_INSTALL_DIR}
+    LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+    ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
 )
 
 add_subdirectory(test)


### PR DESCRIPTION
Fix for proxygen build in circleci for AIRStore OSS project.

In AIRStore's CircleCI job, build failed for proxygen:
module path: /tmp/pip-req-build-96w_jmv0/airstore/_build/deps/proxygen/cmake;/tmp/pip-req-build-96w_jmv0/airstore/_build/deps/proxygen/../opensource/fbcode_builder/CMake;/tmp/pip-req-build-96w_jmv0/airstore/_build/deps/proxygen/build/fbcode_builder/CMake
    -- Found gflags from package config
    CMake Error at proxygen/lib/CMakeLists.txt:266 (install):
      install TARGETS given no ARCHIVE DESTINATION for static library target
      "proxygen".
    
    
    CMake Error at proxygen/httpserver/CMakeLists.txt:31 (install):
      install TARGETS given no ARCHIVE DESTINATION for static library target
      "proxygenhttpserver".
    
    
    CMake Error at proxygen/httpclient/samples/curl/CMakeLists.txt:28 (install):
      install TARGETS given no ARCHIVE DESTINATION for static library target
      "proxygencurl".