### PR TITLE
Add missing boost library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ find_package(Boost 1.58 REQUIRED
     regex
     system
     thread
+    chrono
 )
 
 list(APPEND


### PR DESCRIPTION
Build on alpine complained about missing boost chrono when linkin. This patch fixes the issue