### PR TITLE
Add counter for health check requests per VIP, "SLB_vip_{VIP name}_health_check"

### DIFF
--- a/proxygen/lib/stats/BaseStats.h
+++ b/proxygen/lib/stats/BaseStats.h
@@ -28,6 +28,7 @@ class BaseStats {
   // thread safe via the use of atomics, we may only want single local
   // instance instead of wrapped (per thread) instances.
   using TLCounter = facebook::fb303::CounterWrapper;
+  using TLDynamicTimeseries = facebook::fb303::DynamicTimeseriesWrapper<1>;
   using TLTimeseries = facebook::fb303::TimeseriesPolymorphicWrapper;
   using TLTimeseriesQuarterMinuteOnly =
       facebook::fb303::QuarterMinuteOnlyTimeseriesWrapper;


### PR DESCRIPTION
Summary: Count invocations of proxy_health_rule per VIP. One goal is being able to subtract these counters from the VIP RPS counters to get the non-health request counts.

Reviewed By: ritunp

Differential Revision: D28515267

