### PR TITLE
Make building samples optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,10 @@ option(BUILD_SHARED_LIBS
   a stable ABI."
   OFF
 )
+option(BUILD_SAMPLES
+  "If enabled, proxygen will build various examples/samples"
+  ON
+)
 # Mark BUILD_SHARED_LIBS as an "advanced" option, since enabling it
 # is generally discouraged.
 mark_as_advanced(BUILD_SHARED_LIBS)

--- a/proxygen/httpclient/CMakeLists.txt
+++ b/proxygen/httpclient/CMakeLists.txt
@@ -4,4 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-add_subdirectory(samples)
+if (BUILD_SAMPLES)
+  add_subdirectory(samples)
+endif()

--- a/proxygen/httpserver/CMakeLists.txt
+++ b/proxygen/httpserver/CMakeLists.txt
@@ -35,91 +35,93 @@ install(
     LIBRARY DESTINATION ${LIB_INSTALL_DIR}
 )
 
-add_executable(proxygen_push
-    samples/push/PushServer.cpp
-    samples/push/PushRequestHandler.cpp
-)
-target_compile_options(
-    proxygen_push
-    PRIVATE
-        ${_PROXYGEN_COMMON_COMPILE_OPTIONS}
-)
-target_link_libraries(
-    proxygen_push
-    PUBLIC
-        proxygen
-        proxygenhttpserver
-)
-install(
-    TARGETS proxygen_push
-    EXPORT proxygen-exports
-    DESTINATION bin
-)
+if (BUILD_SAMPLES)
+  add_executable(proxygen_push
+      samples/push/PushServer.cpp
+      samples/push/PushRequestHandler.cpp
+  )
+  target_compile_options(
+      proxygen_push
+      PRIVATE
+          ${_PROXYGEN_COMMON_COMPILE_OPTIONS}
+  )
+  target_link_libraries(
+      proxygen_push
+      PUBLIC
+          proxygen
+          proxygenhttpserver
+  )
+  install(
+      TARGETS proxygen_push
+      EXPORT proxygen-exports
+      DESTINATION bin
+  )
 
-add_executable(proxygen_proxy
-    samples/proxy/ProxyServer.cpp
-    samples/proxy/ProxyHandler.cpp
-)
-target_compile_options(
-    proxygen_proxy
-    PRIVATE
-        ${_PROXYGEN_COMMON_COMPILE_OPTIONS}
-)
-target_link_libraries(
-    proxygen_proxy
-    PUBLIC
-        proxygen
-        proxygenhttpserver
-)
-install(
-    TARGETS proxygen_proxy
-    EXPORT proxygen-exports
-    DESTINATION bin
-)
+  add_executable(proxygen_proxy
+      samples/proxy/ProxyServer.cpp
+      samples/proxy/ProxyHandler.cpp
+  )
+  target_compile_options(
+      proxygen_proxy
+      PRIVATE
+          ${_PROXYGEN_COMMON_COMPILE_OPTIONS}
+  )
+  target_link_libraries(
+      proxygen_proxy
+      PUBLIC
+          proxygen
+          proxygenhttpserver
+  )
+  install(
+      TARGETS proxygen_proxy
+      EXPORT proxygen-exports
+      DESTINATION bin
+  )
 
-add_executable(proxygen_static
-    samples/static/StaticServer.cpp
-    samples/static/StaticHandler.cpp
-)
-target_compile_options(
-    proxygen_static
-    PRIVATE
-        ${_PROXYGEN_COMMON_COMPILE_OPTIONS}
-)
-target_link_libraries(
-    proxygen_static
-    PUBLIC
-        proxygen
-        proxygenhttpserver
-)
-install(
-    TARGETS proxygen_static
-    EXPORT proxygen-exports
-    DESTINATION bin
-)
+  add_executable(proxygen_static
+      samples/static/StaticServer.cpp
+      samples/static/StaticHandler.cpp
+  )
+  target_compile_options(
+      proxygen_static
+      PRIVATE
+          ${_PROXYGEN_COMMON_COMPILE_OPTIONS}
+  )
+  target_link_libraries(
+      proxygen_static
+      PUBLIC
+          proxygen
+          proxygenhttpserver
+  )
+  install(
+      TARGETS proxygen_static
+      EXPORT proxygen-exports
+      DESTINATION bin
+  )
 
-add_executable(proxygen_echo
-    samples/echo/EchoServer.cpp
-    samples/echo/EchoHandler.cpp
-)
-target_compile_options(
-    proxygen_echo
-    PRIVATE
-        ${_PROXYGEN_COMMON_COMPILE_OPTIONS}
-)
-target_link_libraries(
-    proxygen_echo
-    PUBLIC
-        proxygen
-        proxygenhttpserver
-)
-install(
-    TARGETS proxygen_echo
-    EXPORT proxygen-exports
-    DESTINATION bin
-)
+  add_executable(proxygen_echo
+      samples/echo/EchoServer.cpp
+      samples/echo/EchoHandler.cpp
+  )
+  target_compile_options(
+      proxygen_echo
+      PRIVATE
+          ${_PROXYGEN_COMMON_COMPILE_OPTIONS}
+  )
+  target_link_libraries(
+      proxygen_echo
+      PUBLIC
+          proxygen
+          proxygenhttpserver
+  )
+  install(
+      TARGETS proxygen_echo
+      EXPORT proxygen-exports
+      DESTINATION bin
+  )
+endif()
 
-if (BUILD_QUIC)
+if (BUILD_QUIC AND BUILD_SAMPLES)
   add_executable(hq
       samples/hq/main.cpp
       samples/hq/FizzContext.cpp


### PR DESCRIPTION
I'm turning these off in the HHVM build as:
- they are not required
- building them requires sorting out more dependencies, e.g. libglog and
  libgflags

I've left the 'samples' in lib/util as they are actually required, and
don't require additional dependencies.

Test plan: built locally on my mac as part of HHVM build with
-DBUILD_SAMPLES=OFF
