### PR TITLE
Remove boost date_time from dependency list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,6 @@ find_package(Boost 1.58 REQUIRED
   COMPONENTS
     iostreams
     context
-    date_time
     filesystem
     program_options
     regex

--- a/cmake/proxygen-config.cmake.in
+++ b/cmake/proxygen-config.cmake.in
@@ -35,7 +35,6 @@ find_dependency(Boost 1.58 REQUIRED
   COMPONENTS
     iostreams
     context
-    date_time
     filesystem
     program_options
     regex


### PR DESCRIPTION
This appears unused:
- I'm not seeing any `#include <boost/date_time/`
- I'm able to at least build everything without the samples in HHVM
  without it

Original commit says that folly needs this, and it doesn't.

I'm removing the dependency here to avoid adding it to the HHVM build
process (and build time) if the system boost is too old, as part of
switching HHVM from using a custom build system to proxygen to using
proxygen's own cmake.

Test plan: HHVM build without system boost, and D31549863 with this
patch applied to proxygen. This probably isn't sufficent for proxygen
itself, advise appreciated :)
