### PR TITLE
Fix -Wstring-conversion warnings

### DIFF
--- a/proxygen/external/http_parser/http_parser_cpp.cpp
+++ b/proxygen/external/http_parser/http_parser_cpp.cpp
@@ -2414,7 +2414,7 @@ http_parser_parse_url_options(const char *buf, size_t buflen, int is_connect,
         break;
 
       default:
-        assert(!"Unexpected state");
+        assert(false && "Unexpected state");
         return 1;
     }
 


### PR DESCRIPTION
Summary:
clang is particular about not treating strings as booleans, but it offers an "out" by using `expr && "string"` specifically for the use cases of `assert` like ours

**Before**
```
assert(!"Should never happen!"); <-- clang warning: -Wstring-conversion
```

**After**
```
assert(false && "Should never happen!");  <-- no clang warning
```

Differential Revision: D33796856

