### PR TITLE
Use BUILD_QUIC flag in configure script to depend on one of mvfst or Fizz

### DIFF
--- a/cmake/proxygen-config.cmake.in
+++ b/cmake/proxygen-config.cmake.in
@@ -20,8 +20,10 @@ include(CMakeFindDependencyMacro)
 find_dependency(fmt)
 find_dependency(folly)
 find_dependency(wangle)
+if ("@BUILD_QUIC@")
+  find_dependency(mvfst)
+endif()
 find_dependency(Fizz)
-find_dependency(mvfst)
 # For now, anything that depends on Proxygen has to copy its FindZstd.cmake
 # and issue a `find_package(Zstd)`.  Uncommenting this won't work because
 # this Zstd module exposes a library called `zstd`.  The right fix is


### PR DESCRIPTION
We depend on Proxygen in another OSS Facebook project and are unable to use the find script at the moment because we don't use QUIC / depend on mvfst. This change updates the proxygen-provided configure script to only depend on mvfst if BUILD_QUIC is set, and otherwise depend on Fizz, in sync with CMakeLists.txt.