### PR TITLE
Adding ELI5 video to the home page 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ We have a Google group for general discussions at https://groups.google.com/d/fo
 The [original blog post](https://engineering.fb.com/production-engineering/introducing-proxygen-facebook-s-c-http-framework/)
 also has more background on the project.
 
+## Learn More in This Intro Video
+[![Explain Like I’m 5: Proxygen](https://img.youtube.com/vi/OsrBYHIYCYk/0.jpg)](https://www.youtube.com/watch?v=OsrBYHIYCYk)
+
 ### Installing
 
 Note that currently this project has been tested on Ubuntu 18.04 and Mac OSX


### PR DESCRIPTION
## Summary
Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in [Docusaurus home page](https://docusaurus.io/), [Jest](https://jestjs.io/), [Litho](https://fblitho.com/), [Hydra](https://hydra.cc/), etc..

## Test plan:
<img width="720" alt="image" src="https://user-images.githubusercontent.com/12485205/154555529-60c53daf-0d04-4e30-9266-469e6456b1fc.png">
