### PR TITLE
Use a more recent version of fmt library

### DIFF
--- a/proxygen/build.sh
+++ b/proxygen/build.sh
@@ -130,7 +130,7 @@ function setup_fmt() {
   fi
   cd "$FMT_DIR"
   git fetch --tags
-  git checkout 9.0.0
+  git checkout 8.0.1
   echo -e "${COLOR_GREEN}Building fmt ${COLOR_OFF}"
   mkdir -p "$FMT_BUILD_DIR"
   cd "$FMT_BUILD_DIR" || exit

--- a/proxygen/build.sh
+++ b/proxygen/build.sh
@@ -130,7 +130,7 @@ function setup_fmt() {
   fi
   cd "$FMT_DIR"
   git fetch --tags
-  git checkout 6.2.1
+  git checkout 9.0.0
   echo -e "${COLOR_GREEN}Building fmt ${COLOR_OFF}"
   mkdir -p "$FMT_BUILD_DIR"
   cd "$FMT_BUILD_DIR" || exit


### PR DESCRIPTION
The fmt library version is a couple of years old and it's moved on quite a bit since then. The once in use generates warnings with -Wpedantic. 