### PR TITLE
Add CMake option ALLOW_NONEMPTY_204_RESPONSE

### DIFF
--- a/proxygen/lib/CMakeLists.txt
+++ b/proxygen/lib/CMakeLists.txt
@@ -224,6 +224,9 @@ target_compile_options(
     proxygen PRIVATE
     ${_PROXYGEN_COMMON_COMPILE_OPTIONS}
 )
+if (ALLOW_NONEMPTY_204_RESPONSE)
+  target_compile_definitions(proxygen PRIVATE ALLOW_NONEMPTY_204_RESPONSE)
+endif()
 
 if (BUILD_SHARED_LIBS)
     set_property(TARGET proxygen PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/proxygen/lib/http/RFC2616.cpp
+++ b/proxygen/lib/http/RFC2616.cpp
@@ -58,7 +58,11 @@ BodyAllowed isRequestBodyAllowed(folly::Optional<HTTPMethod> method) {
 }
 
 bool responseBodyMustBeEmpty(unsigned status) {
-  return (status == 304 || status == 204 || (100 <= status && status < 200));
+  return (status == 304 ||
+#ifndef ALLOW_NONEMPTY_204_RESPONSE
+          status == 204 ||
+#endif
+          (100 <= status && status < 200));
 }
 
 bool bodyImplied(const HTTPHeaders& headers) {


### PR DESCRIPTION
RFC2616 is very strict when it comes to "204 No Content" responses, requiring them to actually be empty. However, not everyone follows this (that is, they return content in 204 responses), causing otherwise valid HTTP responses to be rejected.

This PR adds a CMake option `ALLOW_NONEMPTY_204_RESPONSE` (which sets a preprocessor macro with the same name) that disables rejecting 204 responses with content, so that you can instead ignore the body of the response in those cases.