### PR TITLE
Add missing #include required for GCC 13

### DIFF
--- a/proxygen/lib/utils/ConsistentHash.h
+++ b/proxygen/lib/utils/ConsistentHash.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
- `<cstdint>` for uint64_t etc.

https://www.gnu.org/software/gcc/gcc-13/porting_to.html