### PR TITLE
Change type of function parameter in TraceEventContext.cpp (#9363)

### DIFF
--- a/proxygen/lib/utils/TraceEventContext.cpp
+++ b/proxygen/lib/utils/TraceEventContext.cpp
@@ -11,7 +11,7 @@
 
 namespace proxygen {
 
-void TraceEventContext::traceEventAvailable(TraceEvent event) {
+void TraceEventContext::traceEventAvailable(const TraceEvent& event) {
   for (const auto observer : observers_) {
     observer->traceEventAvailable(event);
   }

--- a/proxygen/lib/utils/TraceEventContext.h
+++ b/proxygen/lib/utils/TraceEventContext.h
@@ -38,7 +38,7 @@ class TraceEventContext {
     }
   }
 
-  void traceEventAvailable(TraceEvent event);
+  void traceEventAvailable(const TraceEvent& event);
 
   bool isAllTraceEventNeeded() const;
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/hhvm/pull/9363

Function parameter `event` at file `proxygen/lib/utils/TraceEventContext.cpp` is passed by-value but not modified inside the function. This might result in an unnecessary copy at the callsite of this function.

In this diff, we are changing the type of this function parameter to `const &`.

More info see the Opportunity Instance: 208745528568242

Reviewed By: dcsommer, mjoras

Differential Revision: D45574861

