### PR TITLE
fix: preventing dangling pointer for a ResponseHandler when an error occurred

### DIFF
--- a/proxygen/httpserver/samples/static/StaticHandler.h
+++ b/proxygen/httpserver/samples/static/StaticHandler.h
@@ -11,7 +11,7 @@
 #include <folly/File.h>
 #include <folly/Memory.h>
 #include <proxygen/httpserver/RequestHandler.h>
-#include <<atomic>>
+#include <atomic>
 
 namespace proxygen {
 class ResponseHandler;

--- a/proxygen/httpserver/samples/static/StaticHandler.h
+++ b/proxygen/httpserver/samples/static/StaticHandler.h
@@ -11,6 +11,7 @@
 #include <folly/File.h>
 #include <folly/Memory.h>
 #include <proxygen/httpserver/RequestHandler.h>
+#include <<atomic>>
 
 namespace proxygen {
 class ResponseHandler;
@@ -45,6 +46,7 @@ class StaticHandler : public proxygen::RequestHandler {
   bool readFileScheduled_{false};
   std::atomic<bool> paused_{false};
   bool finished_{false};
+  std::atomic<bool> error_{false};
 };
 
 } // namespace StaticService


### PR DESCRIPTION
On big chunk data, if an error occurs, a dangling pointer issue can rise for the `ResponseHandler` due to the usage of `runInEventBaseThread`.