### PR TITLE
Added conditional verification to python executable. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,12 @@ set(PROXYGEN_GENERATED_ROOT ${CMAKE_CURRENT_BINARY_DIR}/generated)
 file(MAKE_DIRECTORY ${PROXYGEN_GENERATED_ROOT})
 
 # Build-time program requirements.
-find_program(PROXYGEN_PYTHON python3)
+if(WIN32)
+    find_program(PROXYGEN_PYTHON python)
+else()
+    find_program(PROXYGEN_PYTHON python3)
+endif()
+
 if(NOT PROXYGEN_PYTHON)
     message(FATAL_ERROR "python is required for the proxygen build")
 endif()


### PR DESCRIPTION
Added conditional verification to python executable to search for python instead of python3 on Windows.

This code without this modification is searching for python as python3.exe in Windows, but in the OS, python is installed as python.exe, what cause an incorrect python not found.

Issue: #499