### PR TITLE
Fix StatusTypeEnum bug

### DIFF
--- a/proxygen/lib/http/StatusTypeEnum.h
+++ b/proxygen/lib/http/StatusTypeEnum.h
@@ -55,7 +55,8 @@ namespace proxygen {
       x(manifest_missing_representation), x(manifest_with_0_bitrate),          \
       x(manifest_with_no_tracks), x(manifest_with_wrong_track),                \
       x(cache_lease_queue_hard_timeout), x(cache_purge), x(cache_error),       \
-      x(proxy_cache_fill_shed), x(ENUM_COUNT), x(takedown_direct_response)
+      x(proxy_cache_fill_shed), x(takedown_direct_response),                   \
+      /* ENUM_COUNT MUST BE THE FINAL ENUM */ x(ENUM_COUNT)
 
 #define STATUS_TYPE_ENUM(statusType) statusType
 


### PR DESCRIPTION
Summary:
`StatusType::ENUM_COUNT` is used to bound the valid enums but its not the last one...
https://www.internalfb.com/code/fbsource/[b40ae6818e8b01d0e37ec0d35afe8f45269c73d1]/fbcode/proxygen/lib/http/StatusTypeEnum.cpp?lines=19-26

Differential Revision: D61672203
