### PR TITLE
Fix OSS build

### DIFF
--- a/build/fbcode_builder/patches/boost_comparator_operator_fix.patch
+++ b/build/fbcode_builder/patches/boost_comparator_operator_fix.patch
@@ -8,4 +8,4 @@ diff --git a/boost/serialization/strong_typedef.hpp b/boost/serialization/strong
 +    bool operator==(const T& lhs) const {return t == lhs;}                                                       \
      bool operator<(const D& rhs) const {return t < rhs.t;}                                                       \
  };
-
+ 

--- a/build/fbcode_builder/patches/zlib_dont_build_more_than_needed.patch
+++ b/build/fbcode_builder/patches/zlib_dont_build_more_than_needed.patch
@@ -4,7 +4,7 @@ diff -Naur ../zlib-1.3.1/CMakeLists.txt ./CMakeLists.txt
 @@ -149,10 +149,8 @@
      set(ZLIB_DLL_SRCS ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj)
  endif(MINGW)
-
+ 
 -add_library(zlib SHARED ${ZLIB_SRCS} ${ZLIB_DLL_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
 +add_library(zlib ${ZLIB_SRCS} ${ZLIB_DLL_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
  target_include_directories(zlib PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
@@ -12,9 +12,9 @@ diff -Naur ../zlib-1.3.1/CMakeLists.txt ./CMakeLists.txt
 -target_include_directories(zlibstatic PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
  set_target_properties(zlib PROPERTIES DEFINE_SYMBOL ZLIB_DLL)
  set_target_properties(zlib PROPERTIES SOVERSION 1)
-
+ 
 @@ -169,7 +167,7 @@
-
+ 
  if(UNIX)
      # On unix-like platforms the library is almost always called libz
 -   set_target_properties(zlib zlibstatic PROPERTIES OUTPUT_NAME z)
@@ -24,10 +24,11 @@ diff -Naur ../zlib-1.3.1/CMakeLists.txt ./CMakeLists.txt
     endif()
 @@ -179,7 +177,7 @@
  endif()
-
+ 
  if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL )
 -    install(TARGETS zlib zlibstatic
 +    install(TARGETS zlib
          RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
          ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
          LIBRARY DESTINATION "${INSTALL_LIB_DIR}" )
+ 


### PR DESCRIPTION
Summary:
https://github.com/facebook/proxygen/issues/510

git patches on Windows OSS proxygen builds been failing for a while because of new lines Windows vs Unix.
I re-generated the patches on Windows and that seems to fix it, and it also works for linux builds so seems fine.

Differential Revision: D63148510
