### PR TITLE
enable system packages for proxygen

### DIFF
--- a/.github/workflows/getdeps_linux.yml
+++ b/.github/workflows/getdeps_linux.yml
@@ -108,93 +108,470 @@ jobs:
     - name: Fetch wangle
       if: ${{ steps.paths.outputs.wangle_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests wangle
-    - name: Build ninja
+    - name: Restore ninja from cache
+      id: restore_ninja
       if: ${{ steps.paths.outputs.ninja_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.ninja_INSTALL }}
+       key: ${{ steps.paths.outputs.ninja_CACHE_KEY }}-install
+    - name: Build ninja
+      if: ${{ steps.paths.outputs.ninja_SOURCE && ! steps.restore_ninja.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests ninja
-    - name: Build cmake
+    - name: Save ninja to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.ninja_SOURCE && ! steps.restore_ninja.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.ninja_INSTALL }}
+       key: ${{ steps.paths.outputs.ninja_CACHE_KEY }}-install
+    - name: Restore cmake from cache
+      id: restore_cmake
       if: ${{ steps.paths.outputs.cmake_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.cmake_INSTALL }}
+       key: ${{ steps.paths.outputs.cmake_CACHE_KEY }}-install
+    - name: Build cmake
+      if: ${{ steps.paths.outputs.cmake_SOURCE && ! steps.restore_cmake.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests cmake
-    - name: Build zlib
+    - name: Save cmake to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.cmake_SOURCE && ! steps.restore_cmake.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.cmake_INSTALL }}
+       key: ${{ steps.paths.outputs.cmake_CACHE_KEY }}-install
+    - name: Restore zlib from cache
+      id: restore_zlib
       if: ${{ steps.paths.outputs.zlib_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.zlib_INSTALL }}
+       key: ${{ steps.paths.outputs.zlib_CACHE_KEY }}-install
+    - name: Build zlib
+      if: ${{ steps.paths.outputs.zlib_SOURCE && ! steps.restore_zlib.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests zlib
-    - name: Build zstd
+    - name: Save zlib to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.zlib_SOURCE && ! steps.restore_zlib.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.zlib_INSTALL }}
+       key: ${{ steps.paths.outputs.zlib_CACHE_KEY }}-install
+    - name: Restore zstd from cache
+      id: restore_zstd
       if: ${{ steps.paths.outputs.zstd_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.zstd_INSTALL }}
+       key: ${{ steps.paths.outputs.zstd_CACHE_KEY }}-install
+    - name: Build zstd
+      if: ${{ steps.paths.outputs.zstd_SOURCE && ! steps.restore_zstd.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests zstd
-    - name: Build boost
+    - name: Save zstd to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.zstd_SOURCE && ! steps.restore_zstd.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.zstd_INSTALL }}
+       key: ${{ steps.paths.outputs.zstd_CACHE_KEY }}-install
+    - name: Restore boost from cache
+      id: restore_boost
       if: ${{ steps.paths.outputs.boost_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.boost_INSTALL }}
+       key: ${{ steps.paths.outputs.boost_CACHE_KEY }}-install
+    - name: Build boost
+      if: ${{ steps.paths.outputs.boost_SOURCE && ! steps.restore_boost.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests boost
-    - name: Build double-conversion
+    - name: Save boost to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.boost_SOURCE && ! steps.restore_boost.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.boost_INSTALL }}
+       key: ${{ steps.paths.outputs.boost_CACHE_KEY }}-install
+    - name: Restore double-conversion from cache
+      id: restore_double-conversion
       if: ${{ steps.paths.outputs.double-conversion_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.double-conversion_INSTALL }}
+       key: ${{ steps.paths.outputs.double-conversion_CACHE_KEY }}-install
+    - name: Build double-conversion
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE && ! steps.restore_double-conversion.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests double-conversion
-    - name: Build fast_float
+    - name: Save double-conversion to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE && ! steps.restore_double-conversion.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.double-conversion_INSTALL }}
+       key: ${{ steps.paths.outputs.double-conversion_CACHE_KEY }}-install
+    - name: Restore fast_float from cache
+      id: restore_fast_float
       if: ${{ steps.paths.outputs.fast_float_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fast_float_INSTALL }}
+       key: ${{ steps.paths.outputs.fast_float_CACHE_KEY }}-install
+    - name: Build fast_float
+      if: ${{ steps.paths.outputs.fast_float_SOURCE && ! steps.restore_fast_float.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests fast_float
-    - name: Build fmt
+    - name: Save fast_float to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fast_float_SOURCE && ! steps.restore_fast_float.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fast_float_INSTALL }}
+       key: ${{ steps.paths.outputs.fast_float_CACHE_KEY }}-install
+    - name: Restore fmt from cache
+      id: restore_fmt
       if: ${{ steps.paths.outputs.fmt_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fmt_INSTALL }}
+       key: ${{ steps.paths.outputs.fmt_CACHE_KEY }}-install
+    - name: Build fmt
+      if: ${{ steps.paths.outputs.fmt_SOURCE && ! steps.restore_fmt.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests fmt
-    - name: Build gflags
+    - name: Save fmt to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fmt_SOURCE && ! steps.restore_fmt.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fmt_INSTALL }}
+       key: ${{ steps.paths.outputs.fmt_CACHE_KEY }}-install
+    - name: Restore gflags from cache
+      id: restore_gflags
       if: ${{ steps.paths.outputs.gflags_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.gflags_INSTALL }}
+       key: ${{ steps.paths.outputs.gflags_CACHE_KEY }}-install
+    - name: Build gflags
+      if: ${{ steps.paths.outputs.gflags_SOURCE && ! steps.restore_gflags.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests gflags
-    - name: Build glog
+    - name: Save gflags to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.gflags_SOURCE && ! steps.restore_gflags.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.gflags_INSTALL }}
+       key: ${{ steps.paths.outputs.gflags_CACHE_KEY }}-install
+    - name: Restore glog from cache
+      id: restore_glog
       if: ${{ steps.paths.outputs.glog_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.glog_INSTALL }}
+       key: ${{ steps.paths.outputs.glog_CACHE_KEY }}-install
+    - name: Build glog
+      if: ${{ steps.paths.outputs.glog_SOURCE && ! steps.restore_glog.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests glog
-    - name: Build googletest
+    - name: Save glog to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.glog_SOURCE && ! steps.restore_glog.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.glog_INSTALL }}
+       key: ${{ steps.paths.outputs.glog_CACHE_KEY }}-install
+    - name: Restore googletest from cache
+      id: restore_googletest
       if: ${{ steps.paths.outputs.googletest_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.googletest_INSTALL }}
+       key: ${{ steps.paths.outputs.googletest_CACHE_KEY }}-install
+    - name: Build googletest
+      if: ${{ steps.paths.outputs.googletest_SOURCE && ! steps.restore_googletest.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests googletest
-    - name: Build libdwarf
+    - name: Save googletest to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.googletest_SOURCE && ! steps.restore_googletest.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.googletest_INSTALL }}
+       key: ${{ steps.paths.outputs.googletest_CACHE_KEY }}-install
+    - name: Restore libdwarf from cache
+      id: restore_libdwarf
       if: ${{ steps.paths.outputs.libdwarf_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libdwarf_INSTALL }}
+       key: ${{ steps.paths.outputs.libdwarf_CACHE_KEY }}-install
+    - name: Build libdwarf
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE && ! steps.restore_libdwarf.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libdwarf
-    - name: Build libevent
+    - name: Save libdwarf to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE && ! steps.restore_libdwarf.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libdwarf_INSTALL }}
+       key: ${{ steps.paths.outputs.libdwarf_CACHE_KEY }}-install
+    - name: Restore libevent from cache
+      id: restore_libevent
       if: ${{ steps.paths.outputs.libevent_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libevent_INSTALL }}
+       key: ${{ steps.paths.outputs.libevent_CACHE_KEY }}-install
+    - name: Build libevent
+      if: ${{ steps.paths.outputs.libevent_SOURCE && ! steps.restore_libevent.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libevent
-    - name: Build lz4
+    - name: Save libevent to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libevent_SOURCE && ! steps.restore_libevent.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libevent_INSTALL }}
+       key: ${{ steps.paths.outputs.libevent_CACHE_KEY }}-install
+    - name: Restore lz4 from cache
+      id: restore_lz4
       if: ${{ steps.paths.outputs.lz4_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.lz4_INSTALL }}
+       key: ${{ steps.paths.outputs.lz4_CACHE_KEY }}-install
+    - name: Build lz4
+      if: ${{ steps.paths.outputs.lz4_SOURCE && ! steps.restore_lz4.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests lz4
-    - name: Build snappy
+    - name: Save lz4 to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.lz4_SOURCE && ! steps.restore_lz4.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.lz4_INSTALL }}
+       key: ${{ steps.paths.outputs.lz4_CACHE_KEY }}-install
+    - name: Restore snappy from cache
+      id: restore_snappy
       if: ${{ steps.paths.outputs.snappy_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.snappy_INSTALL }}
+       key: ${{ steps.paths.outputs.snappy_CACHE_KEY }}-install
+    - name: Build snappy
+      if: ${{ steps.paths.outputs.snappy_SOURCE && ! steps.restore_snappy.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests snappy
-    - name: Build openssl
+    - name: Save snappy to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.snappy_SOURCE && ! steps.restore_snappy.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.snappy_INSTALL }}
+       key: ${{ steps.paths.outputs.snappy_CACHE_KEY }}-install
+    - name: Restore openssl from cache
+      id: restore_openssl
       if: ${{ steps.paths.outputs.openssl_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.openssl_INSTALL }}
+       key: ${{ steps.paths.outputs.openssl_CACHE_KEY }}-install
+    - name: Build openssl
+      if: ${{ steps.paths.outputs.openssl_SOURCE && ! steps.restore_openssl.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests openssl
-    - name: Build liboqs
+    - name: Save openssl to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.openssl_SOURCE && ! steps.restore_openssl.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.openssl_INSTALL }}
+       key: ${{ steps.paths.outputs.openssl_CACHE_KEY }}-install
+    - name: Restore liboqs from cache
+      id: restore_liboqs
       if: ${{ steps.paths.outputs.liboqs_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.liboqs_INSTALL }}
+       key: ${{ steps.paths.outputs.liboqs_CACHE_KEY }}-install
+    - name: Build liboqs
+      if: ${{ steps.paths.outputs.liboqs_SOURCE && ! steps.restore_liboqs.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests liboqs
-    - name: Build autoconf
+    - name: Save liboqs to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.liboqs_SOURCE && ! steps.restore_liboqs.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.liboqs_INSTALL }}
+       key: ${{ steps.paths.outputs.liboqs_CACHE_KEY }}-install
+    - name: Restore autoconf from cache
+      id: restore_autoconf
       if: ${{ steps.paths.outputs.autoconf_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.autoconf_INSTALL }}
+       key: ${{ steps.paths.outputs.autoconf_CACHE_KEY }}-install
+    - name: Build autoconf
+      if: ${{ steps.paths.outputs.autoconf_SOURCE && ! steps.restore_autoconf.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests autoconf
-    - name: Build automake
+    - name: Save autoconf to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.autoconf_SOURCE && ! steps.restore_autoconf.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.autoconf_INSTALL }}
+       key: ${{ steps.paths.outputs.autoconf_CACHE_KEY }}-install
+    - name: Restore automake from cache
+      id: restore_automake
       if: ${{ steps.paths.outputs.automake_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.automake_INSTALL }}
+       key: ${{ steps.paths.outputs.automake_CACHE_KEY }}-install
+    - name: Build automake
+      if: ${{ steps.paths.outputs.automake_SOURCE && ! steps.restore_automake.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests automake
-    - name: Build libtool
+    - name: Save automake to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.automake_SOURCE && ! steps.restore_automake.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.automake_INSTALL }}
+       key: ${{ steps.paths.outputs.automake_CACHE_KEY }}-install
+    - name: Restore libtool from cache
+      id: restore_libtool
       if: ${{ steps.paths.outputs.libtool_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libtool_INSTALL }}
+       key: ${{ steps.paths.outputs.libtool_CACHE_KEY }}-install
+    - name: Build libtool
+      if: ${{ steps.paths.outputs.libtool_SOURCE && ! steps.restore_libtool.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libtool
-    - name: Build gperf
+    - name: Save libtool to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libtool_SOURCE && ! steps.restore_libtool.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libtool_INSTALL }}
+       key: ${{ steps.paths.outputs.libtool_CACHE_KEY }}-install
+    - name: Restore gperf from cache
+      id: restore_gperf
       if: ${{ steps.paths.outputs.gperf_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.gperf_INSTALL }}
+       key: ${{ steps.paths.outputs.gperf_CACHE_KEY }}-install
+    - name: Build gperf
+      if: ${{ steps.paths.outputs.gperf_SOURCE && ! steps.restore_gperf.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests gperf
-    - name: Build libiberty
+    - name: Save gperf to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.gperf_SOURCE && ! steps.restore_gperf.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.gperf_INSTALL }}
+       key: ${{ steps.paths.outputs.gperf_CACHE_KEY }}-install
+    - name: Restore libiberty from cache
+      id: restore_libiberty
       if: ${{ steps.paths.outputs.libiberty_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libiberty_INSTALL }}
+       key: ${{ steps.paths.outputs.libiberty_CACHE_KEY }}-install
+    - name: Build libiberty
+      if: ${{ steps.paths.outputs.libiberty_SOURCE && ! steps.restore_libiberty.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libiberty
-    - name: Build libsodium
+    - name: Save libiberty to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libiberty_SOURCE && ! steps.restore_libiberty.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libiberty_INSTALL }}
+       key: ${{ steps.paths.outputs.libiberty_CACHE_KEY }}-install
+    - name: Restore libsodium from cache
+      id: restore_libsodium
       if: ${{ steps.paths.outputs.libsodium_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libsodium_INSTALL }}
+       key: ${{ steps.paths.outputs.libsodium_CACHE_KEY }}-install
+    - name: Build libsodium
+      if: ${{ steps.paths.outputs.libsodium_SOURCE && ! steps.restore_libsodium.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libsodium
-    - name: Build libunwind
+    - name: Save libsodium to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libsodium_SOURCE && ! steps.restore_libsodium.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libsodium_INSTALL }}
+       key: ${{ steps.paths.outputs.libsodium_CACHE_KEY }}-install
+    - name: Restore libunwind from cache
+      id: restore_libunwind
       if: ${{ steps.paths.outputs.libunwind_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libunwind_INSTALL }}
+       key: ${{ steps.paths.outputs.libunwind_CACHE_KEY }}-install
+    - name: Build libunwind
+      if: ${{ steps.paths.outputs.libunwind_SOURCE && ! steps.restore_libunwind.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libunwind
-    - name: Build xz
+    - name: Save libunwind to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libunwind_SOURCE && ! steps.restore_libunwind.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libunwind_INSTALL }}
+       key: ${{ steps.paths.outputs.libunwind_CACHE_KEY }}-install
+    - name: Restore xz from cache
+      id: restore_xz
       if: ${{ steps.paths.outputs.xz_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.xz_INSTALL }}
+       key: ${{ steps.paths.outputs.xz_CACHE_KEY }}-install
+    - name: Build xz
+      if: ${{ steps.paths.outputs.xz_SOURCE && ! steps.restore_xz.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests xz
-    - name: Build folly
+    - name: Save xz to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.xz_SOURCE && ! steps.restore_xz.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.xz_INSTALL }}
+       key: ${{ steps.paths.outputs.xz_CACHE_KEY }}-install
+    - name: Restore folly from cache
+      id: restore_folly
       if: ${{ steps.paths.outputs.folly_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.folly_INSTALL }}
+       key: ${{ steps.paths.outputs.folly_CACHE_KEY }}-install
+    - name: Build folly
+      if: ${{ steps.paths.outputs.folly_SOURCE && ! steps.restore_folly.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests folly
-    - name: Build fizz
+    - name: Save folly to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.folly_SOURCE && ! steps.restore_folly.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.folly_INSTALL }}
+       key: ${{ steps.paths.outputs.folly_CACHE_KEY }}-install
+    - name: Restore fizz from cache
+      id: restore_fizz
       if: ${{ steps.paths.outputs.fizz_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fizz_INSTALL }}
+       key: ${{ steps.paths.outputs.fizz_CACHE_KEY }}-install
+    - name: Build fizz
+      if: ${{ steps.paths.outputs.fizz_SOURCE && ! steps.restore_fizz.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests fizz
-    - name: Build mvfst
+    - name: Save fizz to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fizz_SOURCE && ! steps.restore_fizz.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fizz_INSTALL }}
+       key: ${{ steps.paths.outputs.fizz_CACHE_KEY }}-install
+    - name: Restore mvfst from cache
+      id: restore_mvfst
       if: ${{ steps.paths.outputs.mvfst_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.mvfst_INSTALL }}
+       key: ${{ steps.paths.outputs.mvfst_CACHE_KEY }}-install
+    - name: Build mvfst
+      if: ${{ steps.paths.outputs.mvfst_SOURCE && ! steps.restore_mvfst.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests mvfst
-    - name: Build wangle
+    - name: Save mvfst to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.mvfst_SOURCE && ! steps.restore_mvfst.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.mvfst_INSTALL }}
+       key: ${{ steps.paths.outputs.mvfst_CACHE_KEY }}-install
+    - name: Restore wangle from cache
+      id: restore_wangle
       if: ${{ steps.paths.outputs.wangle_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.wangle_INSTALL }}
+       key: ${{ steps.paths.outputs.wangle_CACHE_KEY }}-install
+    - name: Build wangle
+      if: ${{ steps.paths.outputs.wangle_SOURCE && ! steps.restore_wangle.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests wangle
+    - name: Save wangle to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.wangle_SOURCE && ! steps.restore_wangle.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.wangle_INSTALL }}
+       key: ${{ steps.paths.outputs.wangle_CACHE_KEY }}-install
     - name: Build proxygen
       run: python3 build/fbcode_builder/getdeps.py build --src-dir=. proxygen  --project-install-prefix proxygen:/usr/local
     - name: Copy artifacts

--- a/.github/workflows/getdeps_linux.yml
+++ b/.github/workflows/getdeps_linux.yml
@@ -18,121 +18,182 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
+    - id: paths
+      name: Query paths
+      run: python3 build/fbcode_builder/getdeps.py query-paths --recursive --src-dir=. proxygen  >> "$GITHUB_OUTPUT"
     - name: Fetch ninja
+      if: ${{ steps.paths.outputs.ninja_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests ninja
     - name: Fetch cmake
+      if: ${{ steps.paths.outputs.cmake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests cmake
     - name: Fetch zlib
+      if: ${{ steps.paths.outputs.zlib_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests zlib
     - name: Fetch zstd
+      if: ${{ steps.paths.outputs.zstd_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests zstd
     - name: Fetch boost
+      if: ${{ steps.paths.outputs.boost_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests boost
     - name: Fetch double-conversion
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests double-conversion
     - name: Fetch fast_float
+      if: ${{ steps.paths.outputs.fast_float_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fast_float
     - name: Fetch fmt
+      if: ${{ steps.paths.outputs.fmt_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fmt
     - name: Fetch gflags
+      if: ${{ steps.paths.outputs.gflags_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests gflags
     - name: Fetch glog
+      if: ${{ steps.paths.outputs.glog_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests glog
     - name: Fetch googletest
+      if: ${{ steps.paths.outputs.googletest_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests googletest
     - name: Fetch libdwarf
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libdwarf
     - name: Fetch libevent
+      if: ${{ steps.paths.outputs.libevent_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libevent
     - name: Fetch lz4
+      if: ${{ steps.paths.outputs.lz4_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests lz4
     - name: Fetch snappy
+      if: ${{ steps.paths.outputs.snappy_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests snappy
     - name: Fetch openssl
+      if: ${{ steps.paths.outputs.openssl_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests openssl
     - name: Fetch liboqs
+      if: ${{ steps.paths.outputs.liboqs_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests liboqs
     - name: Fetch autoconf
+      if: ${{ steps.paths.outputs.autoconf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests autoconf
     - name: Fetch automake
+      if: ${{ steps.paths.outputs.automake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests automake
     - name: Fetch libtool
+      if: ${{ steps.paths.outputs.libtool_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libtool
     - name: Fetch gperf
+      if: ${{ steps.paths.outputs.gperf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests gperf
     - name: Fetch libiberty
+      if: ${{ steps.paths.outputs.libiberty_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libiberty
     - name: Fetch libsodium
+      if: ${{ steps.paths.outputs.libsodium_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libsodium
     - name: Fetch libunwind
+      if: ${{ steps.paths.outputs.libunwind_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libunwind
     - name: Fetch xz
+      if: ${{ steps.paths.outputs.xz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests xz
     - name: Fetch folly
+      if: ${{ steps.paths.outputs.folly_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests folly
     - name: Fetch fizz
+      if: ${{ steps.paths.outputs.fizz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fizz
     - name: Fetch mvfst
+      if: ${{ steps.paths.outputs.mvfst_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests mvfst
     - name: Fetch wangle
+      if: ${{ steps.paths.outputs.wangle_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests wangle
     - name: Build ninja
+      if: ${{ steps.paths.outputs.ninja_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests ninja
     - name: Build cmake
+      if: ${{ steps.paths.outputs.cmake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests cmake
     - name: Build zlib
+      if: ${{ steps.paths.outputs.zlib_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests zlib
     - name: Build zstd
+      if: ${{ steps.paths.outputs.zstd_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests zstd
     - name: Build boost
+      if: ${{ steps.paths.outputs.boost_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests boost
     - name: Build double-conversion
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests double-conversion
     - name: Build fast_float
+      if: ${{ steps.paths.outputs.fast_float_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests fast_float
     - name: Build fmt
+      if: ${{ steps.paths.outputs.fmt_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests fmt
     - name: Build gflags
+      if: ${{ steps.paths.outputs.gflags_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests gflags
     - name: Build glog
+      if: ${{ steps.paths.outputs.glog_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests glog
     - name: Build googletest
+      if: ${{ steps.paths.outputs.googletest_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests googletest
     - name: Build libdwarf
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libdwarf
     - name: Build libevent
+      if: ${{ steps.paths.outputs.libevent_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libevent
     - name: Build lz4
+      if: ${{ steps.paths.outputs.lz4_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests lz4
     - name: Build snappy
+      if: ${{ steps.paths.outputs.snappy_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests snappy
     - name: Build openssl
+      if: ${{ steps.paths.outputs.openssl_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests openssl
     - name: Build liboqs
+      if: ${{ steps.paths.outputs.liboqs_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests liboqs
     - name: Build autoconf
+      if: ${{ steps.paths.outputs.autoconf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests autoconf
     - name: Build automake
+      if: ${{ steps.paths.outputs.automake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests automake
     - name: Build libtool
+      if: ${{ steps.paths.outputs.libtool_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libtool
     - name: Build gperf
+      if: ${{ steps.paths.outputs.gperf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests gperf
     - name: Build libiberty
+      if: ${{ steps.paths.outputs.libiberty_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libiberty
     - name: Build libsodium
+      if: ${{ steps.paths.outputs.libsodium_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libsodium
     - name: Build libunwind
+      if: ${{ steps.paths.outputs.libunwind_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libunwind
     - name: Build xz
+      if: ${{ steps.paths.outputs.xz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests xz
     - name: Build folly
+      if: ${{ steps.paths.outputs.folly_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests folly
     - name: Build fizz
+      if: ${{ steps.paths.outputs.fizz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests fizz
     - name: Build mvfst
+      if: ${{ steps.paths.outputs.mvfst_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests mvfst
     - name: Build wangle
+      if: ${{ steps.paths.outputs.wangle_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests wangle
     - name: Build proxygen
       run: python3 build/fbcode_builder/getdeps.py build --src-dir=. proxygen  --project-install-prefix proxygen:/usr/local

--- a/.github/workflows/getdeps_linux.yml
+++ b/.github/workflows/getdeps_linux.yml
@@ -18,96 +18,100 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
+    - name: Update system package info
+      run: sudo --preserve-env=http_proxy apt update
+    - name: Install system deps
+      run: sudo --preserve-env=http_proxy python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive proxygen && sudo --preserve-env=http_proxy python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive patchelf
     - id: paths
       name: Query paths
-      run: python3 build/fbcode_builder/getdeps.py query-paths --recursive --src-dir=. proxygen  >> "$GITHUB_OUTPUT"
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages query-paths --recursive --src-dir=. proxygen  >> "$GITHUB_OUTPUT"
     - name: Fetch ninja
       if: ${{ steps.paths.outputs.ninja_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests ninja
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests ninja
     - name: Fetch cmake
       if: ${{ steps.paths.outputs.cmake_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests cmake
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests cmake
     - name: Fetch zlib
       if: ${{ steps.paths.outputs.zlib_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests zlib
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zlib
     - name: Fetch zstd
       if: ${{ steps.paths.outputs.zstd_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests zstd
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zstd
     - name: Fetch boost
       if: ${{ steps.paths.outputs.boost_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests boost
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests boost
     - name: Fetch double-conversion
       if: ${{ steps.paths.outputs.double-conversion_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests double-conversion
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests double-conversion
     - name: Fetch fast_float
       if: ${{ steps.paths.outputs.fast_float_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fast_float
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fast_float
     - name: Fetch fmt
       if: ${{ steps.paths.outputs.fmt_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fmt
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fmt
     - name: Fetch gflags
       if: ${{ steps.paths.outputs.gflags_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests gflags
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests gflags
     - name: Fetch glog
       if: ${{ steps.paths.outputs.glog_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests glog
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests glog
     - name: Fetch googletest
       if: ${{ steps.paths.outputs.googletest_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests googletest
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests googletest
     - name: Fetch libdwarf
       if: ${{ steps.paths.outputs.libdwarf_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libdwarf
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libdwarf
     - name: Fetch libevent
       if: ${{ steps.paths.outputs.libevent_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libevent
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libevent
     - name: Fetch lz4
       if: ${{ steps.paths.outputs.lz4_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests lz4
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests lz4
     - name: Fetch snappy
       if: ${{ steps.paths.outputs.snappy_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests snappy
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests snappy
     - name: Fetch openssl
       if: ${{ steps.paths.outputs.openssl_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests openssl
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests openssl
     - name: Fetch liboqs
       if: ${{ steps.paths.outputs.liboqs_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests liboqs
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests liboqs
     - name: Fetch autoconf
       if: ${{ steps.paths.outputs.autoconf_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests autoconf
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests autoconf
     - name: Fetch automake
       if: ${{ steps.paths.outputs.automake_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests automake
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests automake
     - name: Fetch libtool
       if: ${{ steps.paths.outputs.libtool_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libtool
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libtool
     - name: Fetch gperf
       if: ${{ steps.paths.outputs.gperf_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests gperf
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests gperf
     - name: Fetch libiberty
       if: ${{ steps.paths.outputs.libiberty_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libiberty
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libiberty
     - name: Fetch libsodium
       if: ${{ steps.paths.outputs.libsodium_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libsodium
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libsodium
     - name: Fetch libunwind
       if: ${{ steps.paths.outputs.libunwind_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libunwind
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libunwind
     - name: Fetch xz
       if: ${{ steps.paths.outputs.xz_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests xz
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests xz
     - name: Fetch folly
       if: ${{ steps.paths.outputs.folly_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests folly
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests folly
     - name: Fetch fizz
       if: ${{ steps.paths.outputs.fizz_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fizz
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fizz
     - name: Fetch mvfst
       if: ${{ steps.paths.outputs.mvfst_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests mvfst
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests mvfst
     - name: Fetch wangle
       if: ${{ steps.paths.outputs.wangle_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests wangle
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests wangle
     - name: Restore ninja from cache
       id: restore_ninja
       if: ${{ steps.paths.outputs.ninja_SOURCE }}
@@ -117,7 +121,7 @@ jobs:
        key: ${{ steps.paths.outputs.ninja_CACHE_KEY }}-install
     - name: Build ninja
       if: ${{ steps.paths.outputs.ninja_SOURCE && ! steps.restore_ninja.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests ninja
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests ninja
     - name: Save ninja to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.ninja_SOURCE && ! steps.restore_ninja.outputs.cache-hit }}
@@ -133,7 +137,7 @@ jobs:
        key: ${{ steps.paths.outputs.cmake_CACHE_KEY }}-install
     - name: Build cmake
       if: ${{ steps.paths.outputs.cmake_SOURCE && ! steps.restore_cmake.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests cmake
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests cmake
     - name: Save cmake to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.cmake_SOURCE && ! steps.restore_cmake.outputs.cache-hit }}
@@ -149,7 +153,7 @@ jobs:
        key: ${{ steps.paths.outputs.zlib_CACHE_KEY }}-install
     - name: Build zlib
       if: ${{ steps.paths.outputs.zlib_SOURCE && ! steps.restore_zlib.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests zlib
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests zlib
     - name: Save zlib to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.zlib_SOURCE && ! steps.restore_zlib.outputs.cache-hit }}
@@ -165,7 +169,7 @@ jobs:
        key: ${{ steps.paths.outputs.zstd_CACHE_KEY }}-install
     - name: Build zstd
       if: ${{ steps.paths.outputs.zstd_SOURCE && ! steps.restore_zstd.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests zstd
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests zstd
     - name: Save zstd to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.zstd_SOURCE && ! steps.restore_zstd.outputs.cache-hit }}
@@ -181,7 +185,7 @@ jobs:
        key: ${{ steps.paths.outputs.boost_CACHE_KEY }}-install
     - name: Build boost
       if: ${{ steps.paths.outputs.boost_SOURCE && ! steps.restore_boost.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests boost
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests boost
     - name: Save boost to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.boost_SOURCE && ! steps.restore_boost.outputs.cache-hit }}
@@ -197,7 +201,7 @@ jobs:
        key: ${{ steps.paths.outputs.double-conversion_CACHE_KEY }}-install
     - name: Build double-conversion
       if: ${{ steps.paths.outputs.double-conversion_SOURCE && ! steps.restore_double-conversion.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests double-conversion
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests double-conversion
     - name: Save double-conversion to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.double-conversion_SOURCE && ! steps.restore_double-conversion.outputs.cache-hit }}
@@ -213,7 +217,7 @@ jobs:
        key: ${{ steps.paths.outputs.fast_float_CACHE_KEY }}-install
     - name: Build fast_float
       if: ${{ steps.paths.outputs.fast_float_SOURCE && ! steps.restore_fast_float.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests fast_float
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fast_float
     - name: Save fast_float to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.fast_float_SOURCE && ! steps.restore_fast_float.outputs.cache-hit }}
@@ -229,7 +233,7 @@ jobs:
        key: ${{ steps.paths.outputs.fmt_CACHE_KEY }}-install
     - name: Build fmt
       if: ${{ steps.paths.outputs.fmt_SOURCE && ! steps.restore_fmt.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests fmt
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fmt
     - name: Save fmt to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.fmt_SOURCE && ! steps.restore_fmt.outputs.cache-hit }}
@@ -245,7 +249,7 @@ jobs:
        key: ${{ steps.paths.outputs.gflags_CACHE_KEY }}-install
     - name: Build gflags
       if: ${{ steps.paths.outputs.gflags_SOURCE && ! steps.restore_gflags.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests gflags
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests gflags
     - name: Save gflags to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.gflags_SOURCE && ! steps.restore_gflags.outputs.cache-hit }}
@@ -261,7 +265,7 @@ jobs:
        key: ${{ steps.paths.outputs.glog_CACHE_KEY }}-install
     - name: Build glog
       if: ${{ steps.paths.outputs.glog_SOURCE && ! steps.restore_glog.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests glog
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests glog
     - name: Save glog to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.glog_SOURCE && ! steps.restore_glog.outputs.cache-hit }}
@@ -277,7 +281,7 @@ jobs:
        key: ${{ steps.paths.outputs.googletest_CACHE_KEY }}-install
     - name: Build googletest
       if: ${{ steps.paths.outputs.googletest_SOURCE && ! steps.restore_googletest.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests googletest
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests googletest
     - name: Save googletest to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.googletest_SOURCE && ! steps.restore_googletest.outputs.cache-hit }}
@@ -293,7 +297,7 @@ jobs:
        key: ${{ steps.paths.outputs.libdwarf_CACHE_KEY }}-install
     - name: Build libdwarf
       if: ${{ steps.paths.outputs.libdwarf_SOURCE && ! steps.restore_libdwarf.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests libdwarf
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libdwarf
     - name: Save libdwarf to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.libdwarf_SOURCE && ! steps.restore_libdwarf.outputs.cache-hit }}
@@ -309,7 +313,7 @@ jobs:
        key: ${{ steps.paths.outputs.libevent_CACHE_KEY }}-install
     - name: Build libevent
       if: ${{ steps.paths.outputs.libevent_SOURCE && ! steps.restore_libevent.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests libevent
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libevent
     - name: Save libevent to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.libevent_SOURCE && ! steps.restore_libevent.outputs.cache-hit }}
@@ -325,7 +329,7 @@ jobs:
        key: ${{ steps.paths.outputs.lz4_CACHE_KEY }}-install
     - name: Build lz4
       if: ${{ steps.paths.outputs.lz4_SOURCE && ! steps.restore_lz4.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests lz4
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests lz4
     - name: Save lz4 to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.lz4_SOURCE && ! steps.restore_lz4.outputs.cache-hit }}
@@ -341,7 +345,7 @@ jobs:
        key: ${{ steps.paths.outputs.snappy_CACHE_KEY }}-install
     - name: Build snappy
       if: ${{ steps.paths.outputs.snappy_SOURCE && ! steps.restore_snappy.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests snappy
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests snappy
     - name: Save snappy to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.snappy_SOURCE && ! steps.restore_snappy.outputs.cache-hit }}
@@ -357,7 +361,7 @@ jobs:
        key: ${{ steps.paths.outputs.openssl_CACHE_KEY }}-install
     - name: Build openssl
       if: ${{ steps.paths.outputs.openssl_SOURCE && ! steps.restore_openssl.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests openssl
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests openssl
     - name: Save openssl to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.openssl_SOURCE && ! steps.restore_openssl.outputs.cache-hit }}
@@ -373,7 +377,7 @@ jobs:
        key: ${{ steps.paths.outputs.liboqs_CACHE_KEY }}-install
     - name: Build liboqs
       if: ${{ steps.paths.outputs.liboqs_SOURCE && ! steps.restore_liboqs.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests liboqs
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests liboqs
     - name: Save liboqs to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.liboqs_SOURCE && ! steps.restore_liboqs.outputs.cache-hit }}
@@ -389,7 +393,7 @@ jobs:
        key: ${{ steps.paths.outputs.autoconf_CACHE_KEY }}-install
     - name: Build autoconf
       if: ${{ steps.paths.outputs.autoconf_SOURCE && ! steps.restore_autoconf.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests autoconf
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests autoconf
     - name: Save autoconf to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.autoconf_SOURCE && ! steps.restore_autoconf.outputs.cache-hit }}
@@ -405,7 +409,7 @@ jobs:
        key: ${{ steps.paths.outputs.automake_CACHE_KEY }}-install
     - name: Build automake
       if: ${{ steps.paths.outputs.automake_SOURCE && ! steps.restore_automake.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests automake
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests automake
     - name: Save automake to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.automake_SOURCE && ! steps.restore_automake.outputs.cache-hit }}
@@ -421,7 +425,7 @@ jobs:
        key: ${{ steps.paths.outputs.libtool_CACHE_KEY }}-install
     - name: Build libtool
       if: ${{ steps.paths.outputs.libtool_SOURCE && ! steps.restore_libtool.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests libtool
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libtool
     - name: Save libtool to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.libtool_SOURCE && ! steps.restore_libtool.outputs.cache-hit }}
@@ -437,7 +441,7 @@ jobs:
        key: ${{ steps.paths.outputs.gperf_CACHE_KEY }}-install
     - name: Build gperf
       if: ${{ steps.paths.outputs.gperf_SOURCE && ! steps.restore_gperf.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests gperf
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests gperf
     - name: Save gperf to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.gperf_SOURCE && ! steps.restore_gperf.outputs.cache-hit }}
@@ -453,7 +457,7 @@ jobs:
        key: ${{ steps.paths.outputs.libiberty_CACHE_KEY }}-install
     - name: Build libiberty
       if: ${{ steps.paths.outputs.libiberty_SOURCE && ! steps.restore_libiberty.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests libiberty
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libiberty
     - name: Save libiberty to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.libiberty_SOURCE && ! steps.restore_libiberty.outputs.cache-hit }}
@@ -469,7 +473,7 @@ jobs:
        key: ${{ steps.paths.outputs.libsodium_CACHE_KEY }}-install
     - name: Build libsodium
       if: ${{ steps.paths.outputs.libsodium_SOURCE && ! steps.restore_libsodium.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests libsodium
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libsodium
     - name: Save libsodium to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.libsodium_SOURCE && ! steps.restore_libsodium.outputs.cache-hit }}
@@ -485,7 +489,7 @@ jobs:
        key: ${{ steps.paths.outputs.libunwind_CACHE_KEY }}-install
     - name: Build libunwind
       if: ${{ steps.paths.outputs.libunwind_SOURCE && ! steps.restore_libunwind.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests libunwind
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libunwind
     - name: Save libunwind to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.libunwind_SOURCE && ! steps.restore_libunwind.outputs.cache-hit }}
@@ -501,7 +505,7 @@ jobs:
        key: ${{ steps.paths.outputs.xz_CACHE_KEY }}-install
     - name: Build xz
       if: ${{ steps.paths.outputs.xz_SOURCE && ! steps.restore_xz.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests xz
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests xz
     - name: Save xz to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.xz_SOURCE && ! steps.restore_xz.outputs.cache-hit }}
@@ -517,7 +521,7 @@ jobs:
        key: ${{ steps.paths.outputs.folly_CACHE_KEY }}-install
     - name: Build folly
       if: ${{ steps.paths.outputs.folly_SOURCE && ! steps.restore_folly.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests folly
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests folly
     - name: Save folly to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.folly_SOURCE && ! steps.restore_folly.outputs.cache-hit }}
@@ -533,7 +537,7 @@ jobs:
        key: ${{ steps.paths.outputs.fizz_CACHE_KEY }}-install
     - name: Build fizz
       if: ${{ steps.paths.outputs.fizz_SOURCE && ! steps.restore_fizz.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests fizz
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fizz
     - name: Save fizz to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.fizz_SOURCE && ! steps.restore_fizz.outputs.cache-hit }}
@@ -549,7 +553,7 @@ jobs:
        key: ${{ steps.paths.outputs.mvfst_CACHE_KEY }}-install
     - name: Build mvfst
       if: ${{ steps.paths.outputs.mvfst_SOURCE && ! steps.restore_mvfst.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests mvfst
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests mvfst
     - name: Save mvfst to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.mvfst_SOURCE && ! steps.restore_mvfst.outputs.cache-hit }}
@@ -565,7 +569,7 @@ jobs:
        key: ${{ steps.paths.outputs.wangle_CACHE_KEY }}-install
     - name: Build wangle
       if: ${{ steps.paths.outputs.wangle_SOURCE && ! steps.restore_wangle.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests wangle
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests wangle
     - name: Save wangle to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.wangle_SOURCE && ! steps.restore_wangle.outputs.cache-hit }}
@@ -573,12 +577,12 @@ jobs:
        path: ${{ steps.paths.outputs.wangle_INSTALL }}
        key: ${{ steps.paths.outputs.wangle_CACHE_KEY }}-install
     - name: Build proxygen
-      run: python3 build/fbcode_builder/getdeps.py build --src-dir=. proxygen  --project-install-prefix proxygen:/usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. proxygen  --project-install-prefix proxygen:/usr/local
     - name: Copy artifacts
-      run: python3 build/fbcode_builder/getdeps.py fixup-dyn-deps --strip --src-dir=. proxygen _artifacts/linux  --project-install-prefix proxygen:/usr/local --final-install-prefix /usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --strip --src-dir=. proxygen _artifacts/linux  --project-install-prefix proxygen:/usr/local --final-install-prefix /usr/local
     - uses: actions/upload-artifact@v4
       with:
         name: proxygen
         path: _artifacts
     - name: Test proxygen
-      run: python3 build/fbcode_builder/getdeps.py test --src-dir=. proxygen  --project-install-prefix proxygen:/usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages test --src-dir=. proxygen  --project-install-prefix proxygen:/usr/local

--- a/.github/workflows/getdeps_mac.yml
+++ b/.github/workflows/getdeps_mac.yml
@@ -102,87 +102,438 @@ jobs:
     - name: Fetch wangle
       if: ${{ steps.paths.outputs.wangle_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests wangle
-    - name: Build ninja
+    - name: Restore ninja from cache
+      id: restore_ninja
       if: ${{ steps.paths.outputs.ninja_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.ninja_INSTALL }}
+       key: ${{ steps.paths.outputs.ninja_CACHE_KEY }}-install
+    - name: Build ninja
+      if: ${{ steps.paths.outputs.ninja_SOURCE && ! steps.restore_ninja.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests ninja
-    - name: Build cmake
+    - name: Save ninja to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.ninja_SOURCE && ! steps.restore_ninja.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.ninja_INSTALL }}
+       key: ${{ steps.paths.outputs.ninja_CACHE_KEY }}-install
+    - name: Restore cmake from cache
+      id: restore_cmake
       if: ${{ steps.paths.outputs.cmake_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.cmake_INSTALL }}
+       key: ${{ steps.paths.outputs.cmake_CACHE_KEY }}-install
+    - name: Build cmake
+      if: ${{ steps.paths.outputs.cmake_SOURCE && ! steps.restore_cmake.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests cmake
-    - name: Build zlib
+    - name: Save cmake to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.cmake_SOURCE && ! steps.restore_cmake.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.cmake_INSTALL }}
+       key: ${{ steps.paths.outputs.cmake_CACHE_KEY }}-install
+    - name: Restore zlib from cache
+      id: restore_zlib
       if: ${{ steps.paths.outputs.zlib_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.zlib_INSTALL }}
+       key: ${{ steps.paths.outputs.zlib_CACHE_KEY }}-install
+    - name: Build zlib
+      if: ${{ steps.paths.outputs.zlib_SOURCE && ! steps.restore_zlib.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests zlib
-    - name: Build zstd
+    - name: Save zlib to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.zlib_SOURCE && ! steps.restore_zlib.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.zlib_INSTALL }}
+       key: ${{ steps.paths.outputs.zlib_CACHE_KEY }}-install
+    - name: Restore zstd from cache
+      id: restore_zstd
       if: ${{ steps.paths.outputs.zstd_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.zstd_INSTALL }}
+       key: ${{ steps.paths.outputs.zstd_CACHE_KEY }}-install
+    - name: Build zstd
+      if: ${{ steps.paths.outputs.zstd_SOURCE && ! steps.restore_zstd.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests zstd
-    - name: Build boost
+    - name: Save zstd to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.zstd_SOURCE && ! steps.restore_zstd.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.zstd_INSTALL }}
+       key: ${{ steps.paths.outputs.zstd_CACHE_KEY }}-install
+    - name: Restore boost from cache
+      id: restore_boost
       if: ${{ steps.paths.outputs.boost_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.boost_INSTALL }}
+       key: ${{ steps.paths.outputs.boost_CACHE_KEY }}-install
+    - name: Build boost
+      if: ${{ steps.paths.outputs.boost_SOURCE && ! steps.restore_boost.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests boost
-    - name: Build double-conversion
+    - name: Save boost to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.boost_SOURCE && ! steps.restore_boost.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.boost_INSTALL }}
+       key: ${{ steps.paths.outputs.boost_CACHE_KEY }}-install
+    - name: Restore double-conversion from cache
+      id: restore_double-conversion
       if: ${{ steps.paths.outputs.double-conversion_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.double-conversion_INSTALL }}
+       key: ${{ steps.paths.outputs.double-conversion_CACHE_KEY }}-install
+    - name: Build double-conversion
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE && ! steps.restore_double-conversion.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests double-conversion
-    - name: Build fast_float
+    - name: Save double-conversion to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE && ! steps.restore_double-conversion.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.double-conversion_INSTALL }}
+       key: ${{ steps.paths.outputs.double-conversion_CACHE_KEY }}-install
+    - name: Restore fast_float from cache
+      id: restore_fast_float
       if: ${{ steps.paths.outputs.fast_float_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fast_float_INSTALL }}
+       key: ${{ steps.paths.outputs.fast_float_CACHE_KEY }}-install
+    - name: Build fast_float
+      if: ${{ steps.paths.outputs.fast_float_SOURCE && ! steps.restore_fast_float.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests fast_float
-    - name: Build fmt
+    - name: Save fast_float to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fast_float_SOURCE && ! steps.restore_fast_float.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fast_float_INSTALL }}
+       key: ${{ steps.paths.outputs.fast_float_CACHE_KEY }}-install
+    - name: Restore fmt from cache
+      id: restore_fmt
       if: ${{ steps.paths.outputs.fmt_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fmt_INSTALL }}
+       key: ${{ steps.paths.outputs.fmt_CACHE_KEY }}-install
+    - name: Build fmt
+      if: ${{ steps.paths.outputs.fmt_SOURCE && ! steps.restore_fmt.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests fmt
-    - name: Build gflags
+    - name: Save fmt to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fmt_SOURCE && ! steps.restore_fmt.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fmt_INSTALL }}
+       key: ${{ steps.paths.outputs.fmt_CACHE_KEY }}-install
+    - name: Restore gflags from cache
+      id: restore_gflags
       if: ${{ steps.paths.outputs.gflags_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.gflags_INSTALL }}
+       key: ${{ steps.paths.outputs.gflags_CACHE_KEY }}-install
+    - name: Build gflags
+      if: ${{ steps.paths.outputs.gflags_SOURCE && ! steps.restore_gflags.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests gflags
-    - name: Build glog
+    - name: Save gflags to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.gflags_SOURCE && ! steps.restore_gflags.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.gflags_INSTALL }}
+       key: ${{ steps.paths.outputs.gflags_CACHE_KEY }}-install
+    - name: Restore glog from cache
+      id: restore_glog
       if: ${{ steps.paths.outputs.glog_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.glog_INSTALL }}
+       key: ${{ steps.paths.outputs.glog_CACHE_KEY }}-install
+    - name: Build glog
+      if: ${{ steps.paths.outputs.glog_SOURCE && ! steps.restore_glog.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests glog
-    - name: Build googletest
+    - name: Save glog to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.glog_SOURCE && ! steps.restore_glog.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.glog_INSTALL }}
+       key: ${{ steps.paths.outputs.glog_CACHE_KEY }}-install
+    - name: Restore googletest from cache
+      id: restore_googletest
       if: ${{ steps.paths.outputs.googletest_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.googletest_INSTALL }}
+       key: ${{ steps.paths.outputs.googletest_CACHE_KEY }}-install
+    - name: Build googletest
+      if: ${{ steps.paths.outputs.googletest_SOURCE && ! steps.restore_googletest.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests googletest
-    - name: Build libdwarf
+    - name: Save googletest to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.googletest_SOURCE && ! steps.restore_googletest.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.googletest_INSTALL }}
+       key: ${{ steps.paths.outputs.googletest_CACHE_KEY }}-install
+    - name: Restore libdwarf from cache
+      id: restore_libdwarf
       if: ${{ steps.paths.outputs.libdwarf_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libdwarf_INSTALL }}
+       key: ${{ steps.paths.outputs.libdwarf_CACHE_KEY }}-install
+    - name: Build libdwarf
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE && ! steps.restore_libdwarf.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libdwarf
-    - name: Build lz4
+    - name: Save libdwarf to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE && ! steps.restore_libdwarf.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libdwarf_INSTALL }}
+       key: ${{ steps.paths.outputs.libdwarf_CACHE_KEY }}-install
+    - name: Restore lz4 from cache
+      id: restore_lz4
       if: ${{ steps.paths.outputs.lz4_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.lz4_INSTALL }}
+       key: ${{ steps.paths.outputs.lz4_CACHE_KEY }}-install
+    - name: Build lz4
+      if: ${{ steps.paths.outputs.lz4_SOURCE && ! steps.restore_lz4.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests lz4
-    - name: Build openssl
+    - name: Save lz4 to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.lz4_SOURCE && ! steps.restore_lz4.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.lz4_INSTALL }}
+       key: ${{ steps.paths.outputs.lz4_CACHE_KEY }}-install
+    - name: Restore openssl from cache
+      id: restore_openssl
       if: ${{ steps.paths.outputs.openssl_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.openssl_INSTALL }}
+       key: ${{ steps.paths.outputs.openssl_CACHE_KEY }}-install
+    - name: Build openssl
+      if: ${{ steps.paths.outputs.openssl_SOURCE && ! steps.restore_openssl.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests openssl
-    - name: Build snappy
+    - name: Save openssl to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.openssl_SOURCE && ! steps.restore_openssl.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.openssl_INSTALL }}
+       key: ${{ steps.paths.outputs.openssl_CACHE_KEY }}-install
+    - name: Restore snappy from cache
+      id: restore_snappy
       if: ${{ steps.paths.outputs.snappy_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.snappy_INSTALL }}
+       key: ${{ steps.paths.outputs.snappy_CACHE_KEY }}-install
+    - name: Build snappy
+      if: ${{ steps.paths.outputs.snappy_SOURCE && ! steps.restore_snappy.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests snappy
-    - name: Build libevent
+    - name: Save snappy to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.snappy_SOURCE && ! steps.restore_snappy.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.snappy_INSTALL }}
+       key: ${{ steps.paths.outputs.snappy_CACHE_KEY }}-install
+    - name: Restore libevent from cache
+      id: restore_libevent
       if: ${{ steps.paths.outputs.libevent_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libevent_INSTALL }}
+       key: ${{ steps.paths.outputs.libevent_CACHE_KEY }}-install
+    - name: Build libevent
+      if: ${{ steps.paths.outputs.libevent_SOURCE && ! steps.restore_libevent.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libevent
-    - name: Build liboqs
+    - name: Save libevent to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libevent_SOURCE && ! steps.restore_libevent.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libevent_INSTALL }}
+       key: ${{ steps.paths.outputs.libevent_CACHE_KEY }}-install
+    - name: Restore liboqs from cache
+      id: restore_liboqs
       if: ${{ steps.paths.outputs.liboqs_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.liboqs_INSTALL }}
+       key: ${{ steps.paths.outputs.liboqs_CACHE_KEY }}-install
+    - name: Build liboqs
+      if: ${{ steps.paths.outputs.liboqs_SOURCE && ! steps.restore_liboqs.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests liboqs
-    - name: Build autoconf
+    - name: Save liboqs to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.liboqs_SOURCE && ! steps.restore_liboqs.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.liboqs_INSTALL }}
+       key: ${{ steps.paths.outputs.liboqs_CACHE_KEY }}-install
+    - name: Restore autoconf from cache
+      id: restore_autoconf
       if: ${{ steps.paths.outputs.autoconf_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.autoconf_INSTALL }}
+       key: ${{ steps.paths.outputs.autoconf_CACHE_KEY }}-install
+    - name: Build autoconf
+      if: ${{ steps.paths.outputs.autoconf_SOURCE && ! steps.restore_autoconf.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests autoconf
-    - name: Build automake
+    - name: Save autoconf to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.autoconf_SOURCE && ! steps.restore_autoconf.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.autoconf_INSTALL }}
+       key: ${{ steps.paths.outputs.autoconf_CACHE_KEY }}-install
+    - name: Restore automake from cache
+      id: restore_automake
       if: ${{ steps.paths.outputs.automake_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.automake_INSTALL }}
+       key: ${{ steps.paths.outputs.automake_CACHE_KEY }}-install
+    - name: Build automake
+      if: ${{ steps.paths.outputs.automake_SOURCE && ! steps.restore_automake.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests automake
-    - name: Build libtool
+    - name: Save automake to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.automake_SOURCE && ! steps.restore_automake.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.automake_INSTALL }}
+       key: ${{ steps.paths.outputs.automake_CACHE_KEY }}-install
+    - name: Restore libtool from cache
+      id: restore_libtool
       if: ${{ steps.paths.outputs.libtool_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libtool_INSTALL }}
+       key: ${{ steps.paths.outputs.libtool_CACHE_KEY }}-install
+    - name: Build libtool
+      if: ${{ steps.paths.outputs.libtool_SOURCE && ! steps.restore_libtool.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libtool
-    - name: Build gperf
+    - name: Save libtool to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libtool_SOURCE && ! steps.restore_libtool.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libtool_INSTALL }}
+       key: ${{ steps.paths.outputs.libtool_CACHE_KEY }}-install
+    - name: Restore gperf from cache
+      id: restore_gperf
       if: ${{ steps.paths.outputs.gperf_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.gperf_INSTALL }}
+       key: ${{ steps.paths.outputs.gperf_CACHE_KEY }}-install
+    - name: Build gperf
+      if: ${{ steps.paths.outputs.gperf_SOURCE && ! steps.restore_gperf.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests gperf
-    - name: Build libsodium
+    - name: Save gperf to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.gperf_SOURCE && ! steps.restore_gperf.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.gperf_INSTALL }}
+       key: ${{ steps.paths.outputs.gperf_CACHE_KEY }}-install
+    - name: Restore libsodium from cache
+      id: restore_libsodium
       if: ${{ steps.paths.outputs.libsodium_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libsodium_INSTALL }}
+       key: ${{ steps.paths.outputs.libsodium_CACHE_KEY }}-install
+    - name: Build libsodium
+      if: ${{ steps.paths.outputs.libsodium_SOURCE && ! steps.restore_libsodium.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libsodium
-    - name: Build xz
+    - name: Save libsodium to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libsodium_SOURCE && ! steps.restore_libsodium.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libsodium_INSTALL }}
+       key: ${{ steps.paths.outputs.libsodium_CACHE_KEY }}-install
+    - name: Restore xz from cache
+      id: restore_xz
       if: ${{ steps.paths.outputs.xz_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.xz_INSTALL }}
+       key: ${{ steps.paths.outputs.xz_CACHE_KEY }}-install
+    - name: Build xz
+      if: ${{ steps.paths.outputs.xz_SOURCE && ! steps.restore_xz.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests xz
-    - name: Build folly
+    - name: Save xz to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.xz_SOURCE && ! steps.restore_xz.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.xz_INSTALL }}
+       key: ${{ steps.paths.outputs.xz_CACHE_KEY }}-install
+    - name: Restore folly from cache
+      id: restore_folly
       if: ${{ steps.paths.outputs.folly_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.folly_INSTALL }}
+       key: ${{ steps.paths.outputs.folly_CACHE_KEY }}-install
+    - name: Build folly
+      if: ${{ steps.paths.outputs.folly_SOURCE && ! steps.restore_folly.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests folly
-    - name: Build fizz
+    - name: Save folly to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.folly_SOURCE && ! steps.restore_folly.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.folly_INSTALL }}
+       key: ${{ steps.paths.outputs.folly_CACHE_KEY }}-install
+    - name: Restore fizz from cache
+      id: restore_fizz
       if: ${{ steps.paths.outputs.fizz_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fizz_INSTALL }}
+       key: ${{ steps.paths.outputs.fizz_CACHE_KEY }}-install
+    - name: Build fizz
+      if: ${{ steps.paths.outputs.fizz_SOURCE && ! steps.restore_fizz.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests fizz
-    - name: Build mvfst
+    - name: Save fizz to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fizz_SOURCE && ! steps.restore_fizz.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fizz_INSTALL }}
+       key: ${{ steps.paths.outputs.fizz_CACHE_KEY }}-install
+    - name: Restore mvfst from cache
+      id: restore_mvfst
       if: ${{ steps.paths.outputs.mvfst_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.mvfst_INSTALL }}
+       key: ${{ steps.paths.outputs.mvfst_CACHE_KEY }}-install
+    - name: Build mvfst
+      if: ${{ steps.paths.outputs.mvfst_SOURCE && ! steps.restore_mvfst.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests mvfst
-    - name: Build wangle
+    - name: Save mvfst to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.mvfst_SOURCE && ! steps.restore_mvfst.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.mvfst_INSTALL }}
+       key: ${{ steps.paths.outputs.mvfst_CACHE_KEY }}-install
+    - name: Restore wangle from cache
+      id: restore_wangle
       if: ${{ steps.paths.outputs.wangle_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.wangle_INSTALL }}
+       key: ${{ steps.paths.outputs.wangle_CACHE_KEY }}-install
+    - name: Build wangle
+      if: ${{ steps.paths.outputs.wangle_SOURCE && ! steps.restore_wangle.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests wangle
+    - name: Save wangle to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.wangle_SOURCE && ! steps.restore_wangle.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.wangle_INSTALL }}
+       key: ${{ steps.paths.outputs.wangle_CACHE_KEY }}-install
     - name: Build proxygen
       run: python3 build/fbcode_builder/getdeps.py build --src-dir=. proxygen  --project-install-prefix proxygen:/usr/local
     - name: Copy artifacts

--- a/.github/workflows/getdeps_mac.yml
+++ b/.github/workflows/getdeps_mac.yml
@@ -18,113 +18,170 @@ jobs:
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v4
+    - id: paths
+      name: Query paths
+      run: python3 build/fbcode_builder/getdeps.py query-paths --recursive --src-dir=. proxygen  >> "$GITHUB_OUTPUT"
     - name: Fetch ninja
+      if: ${{ steps.paths.outputs.ninja_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests ninja
     - name: Fetch cmake
+      if: ${{ steps.paths.outputs.cmake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests cmake
     - name: Fetch zlib
+      if: ${{ steps.paths.outputs.zlib_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests zlib
     - name: Fetch zstd
+      if: ${{ steps.paths.outputs.zstd_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests zstd
     - name: Fetch boost
+      if: ${{ steps.paths.outputs.boost_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests boost
     - name: Fetch double-conversion
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests double-conversion
     - name: Fetch fast_float
+      if: ${{ steps.paths.outputs.fast_float_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fast_float
     - name: Fetch fmt
+      if: ${{ steps.paths.outputs.fmt_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fmt
     - name: Fetch gflags
+      if: ${{ steps.paths.outputs.gflags_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests gflags
     - name: Fetch glog
+      if: ${{ steps.paths.outputs.glog_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests glog
     - name: Fetch googletest
+      if: ${{ steps.paths.outputs.googletest_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests googletest
     - name: Fetch libdwarf
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libdwarf
     - name: Fetch lz4
+      if: ${{ steps.paths.outputs.lz4_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests lz4
     - name: Fetch openssl
+      if: ${{ steps.paths.outputs.openssl_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests openssl
     - name: Fetch snappy
+      if: ${{ steps.paths.outputs.snappy_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests snappy
     - name: Fetch libevent
+      if: ${{ steps.paths.outputs.libevent_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libevent
     - name: Fetch liboqs
+      if: ${{ steps.paths.outputs.liboqs_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests liboqs
     - name: Fetch autoconf
+      if: ${{ steps.paths.outputs.autoconf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests autoconf
     - name: Fetch automake
+      if: ${{ steps.paths.outputs.automake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests automake
     - name: Fetch libtool
+      if: ${{ steps.paths.outputs.libtool_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libtool
     - name: Fetch gperf
+      if: ${{ steps.paths.outputs.gperf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests gperf
     - name: Fetch libsodium
+      if: ${{ steps.paths.outputs.libsodium_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libsodium
     - name: Fetch xz
+      if: ${{ steps.paths.outputs.xz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests xz
     - name: Fetch folly
+      if: ${{ steps.paths.outputs.folly_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests folly
     - name: Fetch fizz
+      if: ${{ steps.paths.outputs.fizz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fizz
     - name: Fetch mvfst
+      if: ${{ steps.paths.outputs.mvfst_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests mvfst
     - name: Fetch wangle
+      if: ${{ steps.paths.outputs.wangle_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests wangle
     - name: Build ninja
+      if: ${{ steps.paths.outputs.ninja_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests ninja
     - name: Build cmake
+      if: ${{ steps.paths.outputs.cmake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests cmake
     - name: Build zlib
+      if: ${{ steps.paths.outputs.zlib_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests zlib
     - name: Build zstd
+      if: ${{ steps.paths.outputs.zstd_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests zstd
     - name: Build boost
+      if: ${{ steps.paths.outputs.boost_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests boost
     - name: Build double-conversion
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests double-conversion
     - name: Build fast_float
+      if: ${{ steps.paths.outputs.fast_float_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests fast_float
     - name: Build fmt
+      if: ${{ steps.paths.outputs.fmt_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests fmt
     - name: Build gflags
+      if: ${{ steps.paths.outputs.gflags_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests gflags
     - name: Build glog
+      if: ${{ steps.paths.outputs.glog_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests glog
     - name: Build googletest
+      if: ${{ steps.paths.outputs.googletest_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests googletest
     - name: Build libdwarf
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libdwarf
     - name: Build lz4
+      if: ${{ steps.paths.outputs.lz4_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests lz4
     - name: Build openssl
+      if: ${{ steps.paths.outputs.openssl_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests openssl
     - name: Build snappy
+      if: ${{ steps.paths.outputs.snappy_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests snappy
     - name: Build libevent
+      if: ${{ steps.paths.outputs.libevent_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libevent
     - name: Build liboqs
+      if: ${{ steps.paths.outputs.liboqs_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests liboqs
     - name: Build autoconf
+      if: ${{ steps.paths.outputs.autoconf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests autoconf
     - name: Build automake
+      if: ${{ steps.paths.outputs.automake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests automake
     - name: Build libtool
+      if: ${{ steps.paths.outputs.libtool_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libtool
     - name: Build gperf
+      if: ${{ steps.paths.outputs.gperf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests gperf
     - name: Build libsodium
+      if: ${{ steps.paths.outputs.libsodium_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libsodium
     - name: Build xz
+      if: ${{ steps.paths.outputs.xz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests xz
     - name: Build folly
+      if: ${{ steps.paths.outputs.folly_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests folly
     - name: Build fizz
+      if: ${{ steps.paths.outputs.fizz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests fizz
     - name: Build mvfst
+      if: ${{ steps.paths.outputs.mvfst_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests mvfst
     - name: Build wangle
+      if: ${{ steps.paths.outputs.wangle_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py build --no-tests wangle
     - name: Build proxygen
       run: python3 build/fbcode_builder/getdeps.py build --src-dir=. proxygen  --project-install-prefix proxygen:/usr/local

--- a/.github/workflows/getdeps_mac.yml
+++ b/.github/workflows/getdeps_mac.yml
@@ -18,90 +18,92 @@ jobs:
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Install system deps
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive proxygen
     - id: paths
       name: Query paths
-      run: python3 build/fbcode_builder/getdeps.py query-paths --recursive --src-dir=. proxygen  >> "$GITHUB_OUTPUT"
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages query-paths --recursive --src-dir=. proxygen  >> "$GITHUB_OUTPUT"
     - name: Fetch ninja
       if: ${{ steps.paths.outputs.ninja_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests ninja
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests ninja
     - name: Fetch cmake
       if: ${{ steps.paths.outputs.cmake_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests cmake
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests cmake
     - name: Fetch zlib
       if: ${{ steps.paths.outputs.zlib_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests zlib
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zlib
     - name: Fetch zstd
       if: ${{ steps.paths.outputs.zstd_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests zstd
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zstd
     - name: Fetch boost
       if: ${{ steps.paths.outputs.boost_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests boost
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests boost
     - name: Fetch double-conversion
       if: ${{ steps.paths.outputs.double-conversion_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests double-conversion
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests double-conversion
     - name: Fetch fast_float
       if: ${{ steps.paths.outputs.fast_float_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fast_float
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fast_float
     - name: Fetch fmt
       if: ${{ steps.paths.outputs.fmt_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fmt
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fmt
     - name: Fetch gflags
       if: ${{ steps.paths.outputs.gflags_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests gflags
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests gflags
     - name: Fetch glog
       if: ${{ steps.paths.outputs.glog_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests glog
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests glog
     - name: Fetch googletest
       if: ${{ steps.paths.outputs.googletest_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests googletest
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests googletest
     - name: Fetch libdwarf
       if: ${{ steps.paths.outputs.libdwarf_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libdwarf
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libdwarf
     - name: Fetch lz4
       if: ${{ steps.paths.outputs.lz4_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests lz4
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests lz4
     - name: Fetch openssl
       if: ${{ steps.paths.outputs.openssl_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests openssl
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests openssl
     - name: Fetch snappy
       if: ${{ steps.paths.outputs.snappy_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests snappy
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests snappy
     - name: Fetch libevent
       if: ${{ steps.paths.outputs.libevent_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libevent
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libevent
     - name: Fetch liboqs
       if: ${{ steps.paths.outputs.liboqs_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests liboqs
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests liboqs
     - name: Fetch autoconf
       if: ${{ steps.paths.outputs.autoconf_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests autoconf
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests autoconf
     - name: Fetch automake
       if: ${{ steps.paths.outputs.automake_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests automake
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests automake
     - name: Fetch libtool
       if: ${{ steps.paths.outputs.libtool_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libtool
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libtool
     - name: Fetch gperf
       if: ${{ steps.paths.outputs.gperf_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests gperf
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests gperf
     - name: Fetch libsodium
       if: ${{ steps.paths.outputs.libsodium_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libsodium
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libsodium
     - name: Fetch xz
       if: ${{ steps.paths.outputs.xz_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests xz
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests xz
     - name: Fetch folly
       if: ${{ steps.paths.outputs.folly_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests folly
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests folly
     - name: Fetch fizz
       if: ${{ steps.paths.outputs.fizz_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fizz
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fizz
     - name: Fetch mvfst
       if: ${{ steps.paths.outputs.mvfst_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests mvfst
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests mvfst
     - name: Fetch wangle
       if: ${{ steps.paths.outputs.wangle_SOURCE }}
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests wangle
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests wangle
     - name: Restore ninja from cache
       id: restore_ninja
       if: ${{ steps.paths.outputs.ninja_SOURCE }}
@@ -111,7 +113,7 @@ jobs:
        key: ${{ steps.paths.outputs.ninja_CACHE_KEY }}-install
     - name: Build ninja
       if: ${{ steps.paths.outputs.ninja_SOURCE && ! steps.restore_ninja.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests ninja
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests ninja
     - name: Save ninja to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.ninja_SOURCE && ! steps.restore_ninja.outputs.cache-hit }}
@@ -127,7 +129,7 @@ jobs:
        key: ${{ steps.paths.outputs.cmake_CACHE_KEY }}-install
     - name: Build cmake
       if: ${{ steps.paths.outputs.cmake_SOURCE && ! steps.restore_cmake.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests cmake
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests cmake
     - name: Save cmake to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.cmake_SOURCE && ! steps.restore_cmake.outputs.cache-hit }}
@@ -143,7 +145,7 @@ jobs:
        key: ${{ steps.paths.outputs.zlib_CACHE_KEY }}-install
     - name: Build zlib
       if: ${{ steps.paths.outputs.zlib_SOURCE && ! steps.restore_zlib.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests zlib
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests zlib
     - name: Save zlib to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.zlib_SOURCE && ! steps.restore_zlib.outputs.cache-hit }}
@@ -159,7 +161,7 @@ jobs:
        key: ${{ steps.paths.outputs.zstd_CACHE_KEY }}-install
     - name: Build zstd
       if: ${{ steps.paths.outputs.zstd_SOURCE && ! steps.restore_zstd.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests zstd
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests zstd
     - name: Save zstd to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.zstd_SOURCE && ! steps.restore_zstd.outputs.cache-hit }}
@@ -175,7 +177,7 @@ jobs:
        key: ${{ steps.paths.outputs.boost_CACHE_KEY }}-install
     - name: Build boost
       if: ${{ steps.paths.outputs.boost_SOURCE && ! steps.restore_boost.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests boost
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests boost
     - name: Save boost to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.boost_SOURCE && ! steps.restore_boost.outputs.cache-hit }}
@@ -191,7 +193,7 @@ jobs:
        key: ${{ steps.paths.outputs.double-conversion_CACHE_KEY }}-install
     - name: Build double-conversion
       if: ${{ steps.paths.outputs.double-conversion_SOURCE && ! steps.restore_double-conversion.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests double-conversion
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests double-conversion
     - name: Save double-conversion to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.double-conversion_SOURCE && ! steps.restore_double-conversion.outputs.cache-hit }}
@@ -207,7 +209,7 @@ jobs:
        key: ${{ steps.paths.outputs.fast_float_CACHE_KEY }}-install
     - name: Build fast_float
       if: ${{ steps.paths.outputs.fast_float_SOURCE && ! steps.restore_fast_float.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests fast_float
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fast_float
     - name: Save fast_float to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.fast_float_SOURCE && ! steps.restore_fast_float.outputs.cache-hit }}
@@ -223,7 +225,7 @@ jobs:
        key: ${{ steps.paths.outputs.fmt_CACHE_KEY }}-install
     - name: Build fmt
       if: ${{ steps.paths.outputs.fmt_SOURCE && ! steps.restore_fmt.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests fmt
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fmt
     - name: Save fmt to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.fmt_SOURCE && ! steps.restore_fmt.outputs.cache-hit }}
@@ -239,7 +241,7 @@ jobs:
        key: ${{ steps.paths.outputs.gflags_CACHE_KEY }}-install
     - name: Build gflags
       if: ${{ steps.paths.outputs.gflags_SOURCE && ! steps.restore_gflags.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests gflags
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests gflags
     - name: Save gflags to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.gflags_SOURCE && ! steps.restore_gflags.outputs.cache-hit }}
@@ -255,7 +257,7 @@ jobs:
        key: ${{ steps.paths.outputs.glog_CACHE_KEY }}-install
     - name: Build glog
       if: ${{ steps.paths.outputs.glog_SOURCE && ! steps.restore_glog.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests glog
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests glog
     - name: Save glog to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.glog_SOURCE && ! steps.restore_glog.outputs.cache-hit }}
@@ -271,7 +273,7 @@ jobs:
        key: ${{ steps.paths.outputs.googletest_CACHE_KEY }}-install
     - name: Build googletest
       if: ${{ steps.paths.outputs.googletest_SOURCE && ! steps.restore_googletest.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests googletest
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests googletest
     - name: Save googletest to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.googletest_SOURCE && ! steps.restore_googletest.outputs.cache-hit }}
@@ -287,7 +289,7 @@ jobs:
        key: ${{ steps.paths.outputs.libdwarf_CACHE_KEY }}-install
     - name: Build libdwarf
       if: ${{ steps.paths.outputs.libdwarf_SOURCE && ! steps.restore_libdwarf.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests libdwarf
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libdwarf
     - name: Save libdwarf to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.libdwarf_SOURCE && ! steps.restore_libdwarf.outputs.cache-hit }}
@@ -303,7 +305,7 @@ jobs:
        key: ${{ steps.paths.outputs.lz4_CACHE_KEY }}-install
     - name: Build lz4
       if: ${{ steps.paths.outputs.lz4_SOURCE && ! steps.restore_lz4.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests lz4
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests lz4
     - name: Save lz4 to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.lz4_SOURCE && ! steps.restore_lz4.outputs.cache-hit }}
@@ -319,7 +321,7 @@ jobs:
        key: ${{ steps.paths.outputs.openssl_CACHE_KEY }}-install
     - name: Build openssl
       if: ${{ steps.paths.outputs.openssl_SOURCE && ! steps.restore_openssl.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests openssl
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests openssl
     - name: Save openssl to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.openssl_SOURCE && ! steps.restore_openssl.outputs.cache-hit }}
@@ -335,7 +337,7 @@ jobs:
        key: ${{ steps.paths.outputs.snappy_CACHE_KEY }}-install
     - name: Build snappy
       if: ${{ steps.paths.outputs.snappy_SOURCE && ! steps.restore_snappy.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests snappy
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests snappy
     - name: Save snappy to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.snappy_SOURCE && ! steps.restore_snappy.outputs.cache-hit }}
@@ -351,7 +353,7 @@ jobs:
        key: ${{ steps.paths.outputs.libevent_CACHE_KEY }}-install
     - name: Build libevent
       if: ${{ steps.paths.outputs.libevent_SOURCE && ! steps.restore_libevent.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests libevent
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libevent
     - name: Save libevent to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.libevent_SOURCE && ! steps.restore_libevent.outputs.cache-hit }}
@@ -367,7 +369,7 @@ jobs:
        key: ${{ steps.paths.outputs.liboqs_CACHE_KEY }}-install
     - name: Build liboqs
       if: ${{ steps.paths.outputs.liboqs_SOURCE && ! steps.restore_liboqs.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests liboqs
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests liboqs
     - name: Save liboqs to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.liboqs_SOURCE && ! steps.restore_liboqs.outputs.cache-hit }}
@@ -383,7 +385,7 @@ jobs:
        key: ${{ steps.paths.outputs.autoconf_CACHE_KEY }}-install
     - name: Build autoconf
       if: ${{ steps.paths.outputs.autoconf_SOURCE && ! steps.restore_autoconf.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests autoconf
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests autoconf
     - name: Save autoconf to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.autoconf_SOURCE && ! steps.restore_autoconf.outputs.cache-hit }}
@@ -399,7 +401,7 @@ jobs:
        key: ${{ steps.paths.outputs.automake_CACHE_KEY }}-install
     - name: Build automake
       if: ${{ steps.paths.outputs.automake_SOURCE && ! steps.restore_automake.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests automake
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests automake
     - name: Save automake to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.automake_SOURCE && ! steps.restore_automake.outputs.cache-hit }}
@@ -415,7 +417,7 @@ jobs:
        key: ${{ steps.paths.outputs.libtool_CACHE_KEY }}-install
     - name: Build libtool
       if: ${{ steps.paths.outputs.libtool_SOURCE && ! steps.restore_libtool.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests libtool
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libtool
     - name: Save libtool to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.libtool_SOURCE && ! steps.restore_libtool.outputs.cache-hit }}
@@ -431,7 +433,7 @@ jobs:
        key: ${{ steps.paths.outputs.gperf_CACHE_KEY }}-install
     - name: Build gperf
       if: ${{ steps.paths.outputs.gperf_SOURCE && ! steps.restore_gperf.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests gperf
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests gperf
     - name: Save gperf to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.gperf_SOURCE && ! steps.restore_gperf.outputs.cache-hit }}
@@ -447,7 +449,7 @@ jobs:
        key: ${{ steps.paths.outputs.libsodium_CACHE_KEY }}-install
     - name: Build libsodium
       if: ${{ steps.paths.outputs.libsodium_SOURCE && ! steps.restore_libsodium.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests libsodium
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libsodium
     - name: Save libsodium to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.libsodium_SOURCE && ! steps.restore_libsodium.outputs.cache-hit }}
@@ -463,7 +465,7 @@ jobs:
        key: ${{ steps.paths.outputs.xz_CACHE_KEY }}-install
     - name: Build xz
       if: ${{ steps.paths.outputs.xz_SOURCE && ! steps.restore_xz.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests xz
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests xz
     - name: Save xz to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.xz_SOURCE && ! steps.restore_xz.outputs.cache-hit }}
@@ -479,7 +481,7 @@ jobs:
        key: ${{ steps.paths.outputs.folly_CACHE_KEY }}-install
     - name: Build folly
       if: ${{ steps.paths.outputs.folly_SOURCE && ! steps.restore_folly.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests folly
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests folly
     - name: Save folly to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.folly_SOURCE && ! steps.restore_folly.outputs.cache-hit }}
@@ -495,7 +497,7 @@ jobs:
        key: ${{ steps.paths.outputs.fizz_CACHE_KEY }}-install
     - name: Build fizz
       if: ${{ steps.paths.outputs.fizz_SOURCE && ! steps.restore_fizz.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests fizz
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fizz
     - name: Save fizz to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.fizz_SOURCE && ! steps.restore_fizz.outputs.cache-hit }}
@@ -511,7 +513,7 @@ jobs:
        key: ${{ steps.paths.outputs.mvfst_CACHE_KEY }}-install
     - name: Build mvfst
       if: ${{ steps.paths.outputs.mvfst_SOURCE && ! steps.restore_mvfst.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests mvfst
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests mvfst
     - name: Save mvfst to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.mvfst_SOURCE && ! steps.restore_mvfst.outputs.cache-hit }}
@@ -527,7 +529,7 @@ jobs:
        key: ${{ steps.paths.outputs.wangle_CACHE_KEY }}-install
     - name: Build wangle
       if: ${{ steps.paths.outputs.wangle_SOURCE && ! steps.restore_wangle.outputs.cache-hit }}
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests wangle
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests wangle
     - name: Save wangle to cache
       uses: actions/cache/save@v4
       if: ${{ steps.paths.outputs.wangle_SOURCE && ! steps.restore_wangle.outputs.cache-hit }}
@@ -535,12 +537,12 @@ jobs:
        path: ${{ steps.paths.outputs.wangle_INSTALL }}
        key: ${{ steps.paths.outputs.wangle_CACHE_KEY }}-install
     - name: Build proxygen
-      run: python3 build/fbcode_builder/getdeps.py build --src-dir=. proxygen  --project-install-prefix proxygen:/usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. proxygen  --project-install-prefix proxygen:/usr/local
     - name: Copy artifacts
-      run: python3 build/fbcode_builder/getdeps.py fixup-dyn-deps --src-dir=. proxygen _artifacts/mac  --project-install-prefix proxygen:/usr/local --final-install-prefix /usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. proxygen _artifacts/mac  --project-install-prefix proxygen:/usr/local --final-install-prefix /usr/local
     - uses: actions/upload-artifact@v4
       with:
         name: proxygen
         path: _artifacts
     - name: Test proxygen
-      run: python3 build/fbcode_builder/getdeps.py test --src-dir=. proxygen  --project-install-prefix proxygen:/usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages test --src-dir=. proxygen  --project-install-prefix proxygen:/usr/local

--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -552,6 +552,33 @@ class ShowInstDirCmd(ProjectCmdBase):
         )
 
 
+@cmd("query-paths", "print the paths for tooling to use")
+class QueryPathsCmd(ProjectCmdBase):
+    def run_project_cmd(self, args, loader, manifest):
+        if args.recursive:
+            manifests = loader.manifests_in_dependency_order()
+        else:
+            manifests = [manifest]
+
+        for m in manifests:
+            fetcher = loader.create_fetcher(m)
+            if isinstance(fetcher, SystemPackageFetcher):
+                # We are guaranteed that if the fetcher is set to
+                # SystemPackageFetcher then this item is completely
+                # satisfied by the appropriate system packages
+                continue
+            src_dir = fetcher.get_src_dir()
+            print(f"{m.name}_SOURCE={src_dir}")
+
+    def setup_project_cmd_parser(self, parser):
+        parser.add_argument(
+            "--recursive",
+            help="print the transitive deps also",
+            action="store_true",
+            default=False,
+        )
+
+
 @cmd("show-source-dir", "print the source dir for a given project")
 class ShowSourceDirCmd(ProjectCmdBase):
     def run_project_cmd(self, args, loader, manifest):
@@ -1001,6 +1028,10 @@ class GenerateGitHubActionsCmd(ProjectCmdBase):
             manifest_ctx.set("test", "on")
         run_on = self.get_run_on(args)
 
+        tests_arg = "--no-tests "
+        if run_tests:
+            tests_arg = ""
+
         # Some projects don't do anything "useful" as a leaf project, only
         # as a dep for a leaf project. Check for those here; we don't want
         # to waste the effort scheduling them on CI.
@@ -1086,12 +1117,14 @@ jobs:
                 )
                 out.write("      shell: cmd\n")
 
-                # The git installation may not like long filenames, so tell it
-                # that we want it to use them!
                 out.write("    - name: Fix Git config\n")
-                out.write("      run: git config --system core.longpaths true\n")
-                out.write("    - name: Disable autocrlf\n")
-                out.write("      run: git config --system core.autocrlf false\n")
+                out.write("      run: >\n")
+                out.write("        git config --system core.longpaths true &&\n")
+                out.write("        git config --system core.autocrlf false &&\n")
+                # cxx crate needs symlinks enabled
+                out.write("        git config --system core.symlinks true\n")
+                # && is not supported on default windows powershell, so use cmd
+                out.write("      shell: cmd\n")
 
             out.write("    - uses: actions/checkout@v4\n")
 
@@ -1127,17 +1160,12 @@ jobs:
                 if build_opts.is_darwin():
                     # brew is installed as regular user
                     sudo_arg = ""
-                tests_arg = "--no-tests "
-                if run_tests:
-                    tests_arg = ""
-                out.write(
-                    f"      run: {sudo_arg}python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps {tests_arg}--recursive {manifest.name}\n"
-                )
+
+                system_deps_cmd = f"{sudo_arg}{getdepscmd}{allow_sys_arg} install-system-deps {tests_arg}--recursive {manifest.name}"
                 if build_opts.is_linux() or build_opts.is_freebsd():
-                    out.write("    - name: Install packaging system deps\n")
-                    out.write(
-                        f"      run: {sudo_arg}python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps {tests_arg}--recursive patchelf\n"
-                    )
+                    system_deps_cmd += f" && {sudo_arg}{getdepscmd}{allow_sys_arg} install-system-deps {tests_arg}--recursive patchelf"
+                out.write(f"      run: {system_deps_cmd}\n")
+
                 required_locales = manifest.get(
                     "github.actions", "required_locales", ctx=manifest_ctx
                 )
@@ -1151,6 +1179,18 @@ jobs:
                     for loc in required_locales.split():
                         out.write(f"    - name: Ensure {loc} locale present\n")
                         out.write(f"      run: {sudo_arg}locale-gen {loc}\n")
+
+            out.write("    - id: paths\n")
+            out.write("      name: Query paths\n")
+            if build_opts.is_windows():
+                out.write(
+                    f"      run: {getdepscmd}{allow_sys_arg} query-paths {tests_arg}--recursive --src-dir=. {manifest.name}  >> $env:GITHUB_OUTPUT\n"
+                )
+                out.write("      shell: pwsh\n")
+            else:
+                out.write(
+                    f'      run: {getdepscmd}{allow_sys_arg} query-paths {tests_arg}--recursive --src-dir=. {manifest.name}  >> "$GITHUB_OUTPUT"\n'
+                )
 
             projects = loader.manifests_in_dependency_order()
 
@@ -1179,24 +1219,31 @@ jobs:
                 if m.get_repo_url(ctx) != main_repo_url:
                     out.write("    - name: Fetch %s\n" % m.name)
                     out.write(
+                        f"      if: ${{{{ steps.paths.outputs.{m.name}_SOURCE }}}}\n"
+                    )
+                    out.write(
                         f"      run: {getdepscmd}{allow_sys_arg} fetch --no-tests {m.name}\n"
                     )
 
             for m in projects:
-                if m != manifest:
-                    if m.name == "rust":
-                        continue
-                    else:
-                        src_dir_arg = ""
-                        ctx = loader.ctx_gen.get_context(m.name)
-                        if main_repo_url and m.get_repo_url(ctx) == main_repo_url:
-                            # Its in the same repo, so src-dir is also .
-                            src_dir_arg = "--src-dir=. "
-                            has_same_repo_dep = True
-                        out.write("    - name: Build %s\n" % m.name)
-                        out.write(
-                            f"      run: {getdepscmd}{allow_sys_arg} build {build_type_arg}{src_dir_arg}{free_up_disk}--no-tests {m.name}\n"
-                        )
+                if m == manifest or m.name == "rust":
+                    continue
+                src_dir_arg = ""
+                ctx = loader.ctx_gen.get_context(m.name)
+                if main_repo_url and m.get_repo_url(ctx) == main_repo_url:
+                    # Its in the same repo, so src-dir is also .
+                    src_dir_arg = "--src-dir=. "
+                    has_same_repo_dep = True
+
+                out.write("    - name: Build %s\n" % m.name)
+                if not src_dir_arg:
+                    # only run the step if needed
+                    out.write(
+                        f"      if: ${{{{ steps.paths.outputs.{m.name}_SOURCE }}}}\n"
+                    )
+                out.write(
+                    f"      run: {getdepscmd}{allow_sys_arg} build {build_type_arg}{src_dir_arg}{free_up_disk}--no-tests {m.name}\n"
+                )
 
             out.write("    - name: Build %s\n" % manifest.name)
 
@@ -1213,12 +1260,8 @@ jobs:
             if has_same_repo_dep:
                 no_deps_arg = "--no-deps "
 
-            no_tests_arg = ""
-            if not run_tests:
-                no_tests_arg = "--no-tests "
-
             out.write(
-                f"      run: {getdepscmd}{allow_sys_arg} build {build_type_arg}{no_tests_arg}{no_deps_arg}--src-dir=. {manifest.name} {project_prefix}\n"
+                f"      run: {getdepscmd}{allow_sys_arg} build {build_type_arg}{tests_arg}{no_deps_arg}--src-dir=. {manifest.name} {project_prefix}\n"
             )
 
             out.write("    - name: Copy artifacts\n")

--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -440,7 +440,13 @@ class InstallSysDepsCmd(ProjectCmdBase):
         elif manager == "deb":
             packages = sorted(set(all_packages["deb"]))
             if packages:
-                cmd_args = ["sudo", "apt", "install", "-y"] + packages
+                cmd_args = [
+                    "sudo",
+                    "--preserve-env=http_proxy",
+                    "apt",
+                    "install",
+                    "-y",
+                ] + packages
         elif manager == "homebrew":
             packages = sorted(set(all_packages["homebrew"]))
             if packages:
@@ -1155,11 +1161,11 @@ jobs:
                 build_opts.allow_system_packages
                 and build_opts.host_type.get_package_manager()
             ):
-                sudo_arg = "sudo "
+                sudo_arg = "sudo --preserve-env=http_proxy "
                 allow_sys_arg = " --allow-system-packages"
                 if build_opts.host_type.get_package_manager() == "deb":
                     out.write("    - name: Update system package info\n")
-                    out.write(f"      run: {sudo_arg}apt-get update\n")
+                    out.write(f"      run: {sudo_arg}apt update\n")
 
                 out.write("    - name: Install system deps\n")
                 if build_opts.is_darwin():
@@ -1180,7 +1186,7 @@ jobs:
                 ):
                     # ubuntu doesn't include this by default
                     out.write("    - name: Install locale-gen\n")
-                    out.write(f"      run: {sudo_arg}apt-get install locales\n")
+                    out.write(f"      run: {sudo_arg}apt install locales\n")
                     for loc in required_locales.split():
                         out.write(f"    - name: Ensure {loc} locale present\n")
                         out.write(f"      run: {sudo_arg}locale-gen {loc}\n")

--- a/build/fbcode_builder/getdeps/cargo.py
+++ b/build/fbcode_builder/getdeps/cargo.py
@@ -82,6 +82,14 @@ class CargoBuilder(BuilderBase):
                 shutil.rmtree(dst)
         simple_copytree(src, dst)
 
+    def recreate_linked_dir(self, src, dst) -> None:
+        if os.path.isdir(dst):
+            if os.path.islink(dst):
+                os.remove(dst)
+            elif os.path.isdir(dst):
+                shutil.rmtree(dst)
+        os.symlink(src, dst)
+
     def cargo_config_file(self):
         build_source_dir = self.build_dir
         if self.cargo_config_file_subdir:
@@ -191,7 +199,9 @@ incremental = false
                     ],
                 )
 
-        self.recreate_dir(build_source_dir, os.path.join(self.inst_dir, "source"))
+        self.recreate_linked_dir(
+            build_source_dir, os.path.join(self.inst_dir, "source")
+        )
 
     def run_tests(self, schedule_type, owner, test_filter, retry, no_testpilot) -> None:
         if test_filter:

--- a/build/fbcode_builder/getdeps/fetcher.py
+++ b/build/fbcode_builder/getdeps/fetcher.py
@@ -244,7 +244,9 @@ class GitFetcher(Fetcher):
                     if not m:
                         raise Exception("Failed to parse rev from %s" % hash_file)
                     rev = m.group(1)
-                    print("Using pinned rev %s for %s" % (rev, repo_url))
+                    print(
+                        "Using pinned rev %s for %s" % (rev, repo_url), file=sys.stderr
+                    )
 
         self.rev = rev or "main"
         self.origin_repo = repo_url


### PR DESCRIPTION
Summary:
update proxgen github builds to use system packages

github mac runners have python3.13 installed, which has removed the pipes module.  proxygen jobs are configured not to use the homebrew system packages, so it tries to build ninja from source, which fails as it uses pipes in its build script.

Differential Revision: D67866148


