### PR TITLE
Clear read callback on EOF

### DIFF
--- a/proxygen/lib/http/session/HQSession.cpp
+++ b/proxygen/lib/http/session/HQSession.cpp
@@ -3940,12 +3940,14 @@ HQSession::HQStreamTransport::resumeWebTransportIngress(
 
 folly::Expected<folly::Unit, WebTransport::ErrorCode>
 HQSession::HQStreamTransport::stopReadingWebTransportIngress(
-    HTTPCodec::StreamID id, uint32_t errorCode) {
+    HTTPCodec::StreamID id, folly::Optional<uint32_t> errorCode) {
   if (session_.sock_) {
-    auto res = session_.sock_->setReadCallback(
-        id,
-        nullptr,
-        quic::ApplicationErrorCode(WebTransport::toHTTPErrorCode(errorCode)));
+    quic::Optional<quic::ApplicationErrorCode> quicErrorCode;
+    if (errorCode) {
+      quicErrorCode =
+          quic::ApplicationErrorCode(WebTransport::toHTTPErrorCode(*errorCode));
+    }
+    auto res = session_.sock_->setReadCallback(id, nullptr, quicErrorCode);
     if (res.hasError()) {
       return folly::makeUnexpected(WebTransport::ErrorCode::GENERIC_ERROR);
     }

--- a/proxygen/lib/http/session/HQSession.h
+++ b/proxygen/lib/http/session/HQSession.h
@@ -1878,8 +1878,9 @@ class HQSession
         resumeWebTransportIngress(HTTPCodec::StreamID /*id*/) override;
 
     folly::Expected<folly::Unit, WebTransport::ErrorCode>
-        stopReadingWebTransportIngress(HTTPCodec::StreamID /*id*/,
-                                       uint32_t /*errorCode*/) override;
+        stopReadingWebTransportIngress(
+            HTTPCodec::StreamID /*id*/,
+            folly::Optional<uint32_t> /*errorCode*/) override;
 
   }; // HQStreamTransport
 

--- a/proxygen/lib/http/session/HTTPTransaction.h
+++ b/proxygen/lib/http/session/HTTPTransaction.h
@@ -739,8 +739,9 @@ class HTTPTransaction
     }
 
     folly::Expected<folly::Unit, WebTransport::ErrorCode>
-    stopReadingWebTransportIngress(HTTPCodec::StreamID /*id*/,
-                                   uint32_t /*errorCode*/) override {
+    stopReadingWebTransportIngress(
+        HTTPCodec::StreamID /*id*/,
+        folly::Optional<uint32_t> /*errorCode*/) override {
       LOG(FATAL) << __func__ << " not supported";
       folly::assume_unreachable();
     }

--- a/proxygen/lib/http/session/test/HTTPTransactionMocks.h
+++ b/proxygen/lib/http/session/test/HTTPTransactionMocks.h
@@ -261,7 +261,7 @@ class MockHTTPTransactionTransport : public HTTPTransaction::Transport {
               (HTTPCodec::StreamID));
   MOCK_METHOD((folly::Expected<folly::Unit, WebTransport::ErrorCode>),
               stopReadingWebTransportIngress,
-              (HTTPCodec::StreamID, uint32_t));
+              (HTTPCodec::StreamID, folly::Optional<uint32_t>));
 
   MOCK_METHOD(void, trackEgressBodyOffset, (uint64_t, ByteEvent::EventFlags));
 

--- a/proxygen/lib/http/webtransport/QuicWebTransport.cpp
+++ b/proxygen/lib/http/webtransport/QuicWebTransport.cpp
@@ -168,11 +168,14 @@ QuicWebTransport::resumeWebTransportIngress(HTTPCodec::StreamID id) {
 }
 
 folly::Expected<folly::Unit, WebTransport::ErrorCode>
-QuicWebTransport::stopReadingWebTransportIngress(HTTPCodec::StreamID id,
-                                                 uint32_t errorCode) {
+QuicWebTransport::stopReadingWebTransportIngress(
+    HTTPCodec::StreamID id, folly::Optional<uint32_t> errorCode) {
   XCHECK(quicSocket_);
-  auto res = quicSocket_->setReadCallback(
-      id, nullptr, quic::ApplicationErrorCode(errorCode));
+  quic::Optional<quic::ApplicationErrorCode> quicErrorCode;
+  if (errorCode) {
+    quicErrorCode = quic::ApplicationErrorCode(*errorCode);
+  }
+  auto res = quicSocket_->setReadCallback(id, nullptr, quicErrorCode);
   if (res.hasError()) {
     return folly::makeUnexpected(WebTransport::ErrorCode::GENERIC_ERROR);
   }

--- a/proxygen/lib/http/webtransport/QuicWebTransport.h
+++ b/proxygen/lib/http/webtransport/QuicWebTransport.h
@@ -111,8 +111,9 @@ class QuicWebTransport
       resumeWebTransportIngress(HTTPCodec::StreamID /*id*/) override;
 
   folly::Expected<folly::Unit, WebTransport::ErrorCode>
-      stopReadingWebTransportIngress(HTTPCodec::StreamID /*id*/,
-                                     uint32_t /*errorCode*/) override;
+      stopReadingWebTransportIngress(
+          HTTPCodec::StreamID /*id*/,
+          folly::Optional<uint32_t> /*errorCode*/) override;
 
   folly::Expected<folly::Unit, WebTransport::ErrorCode> sendDatagram(
       std::unique_ptr<folly::IOBuf> /*datagram*/) override;

--- a/proxygen/lib/http/webtransport/WebTransportImpl.h
+++ b/proxygen/lib/http/webtransport/WebTransportImpl.h
@@ -62,8 +62,9 @@ class WebTransportImpl : public WebTransport {
         resumeWebTransportIngress(HTTPCodec::StreamID /*id*/) = 0;
 
     virtual folly::Expected<folly::Unit, WebTransport::ErrorCode>
-        stopReadingWebTransportIngress(HTTPCodec::StreamID /*id*/,
-                                       uint32_t /*errorCode*/) = 0;
+        stopReadingWebTransportIngress(
+            HTTPCodec::StreamID /*id*/,
+            folly::Optional<uint32_t> /*errorCode*/) = 0;
     virtual folly::Expected<folly::Unit, WebTransport::ErrorCode> sendDatagram(
         std::unique_ptr<folly::IOBuf> /*datagram*/) = 0;
 
@@ -273,7 +274,8 @@ class WebTransportImpl : public WebTransport {
       HTTPCodec::StreamID id, uint32_t errorCode);
 
   folly::Expected<folly::Unit, WebTransport::ErrorCode>
-  stopReadingWebTransportIngress(HTTPCodec::StreamID id, uint32_t errorCode);
+  stopReadingWebTransportIngress(HTTPCodec::StreamID id,
+                                 folly::Optional<uint32_t> errorCode);
 
   folly::Expected<WebTransport::BidiStreamHandle, WebTransport::ErrorCode>
   newWebTransportBidiStream();


### PR DESCRIPTION
Summary: mvfst can deliver readError after an EOF if the stream still has the read callback set.  After we delete the read callback (from the ingress stream map) we need to clear the callback to prevent UAF.

Differential Revision: D69469439


