### PR TITLE
Fix OSS build failures

### DIFF
--- a/proxygen/lib/CMakeLists.txt
+++ b/proxygen/lib/CMakeLists.txt
@@ -105,6 +105,8 @@ set(
 # append proxygen::coro sources
 set(
     PROXYGEN_CORO_SOURCES
+    dns/CAresResolver.cpp
+    dns/CachingDNSResolver.cpp
     dns/DNSModule.cpp
     dns/DNSResolver.cpp
     dns/Rfc6724.cpp
@@ -307,6 +309,7 @@ target_link_libraries(
     Boost::iostreams
     ZLIB::ZLIB
     ${HTTP3_DEPEND_LIBS}
+    cares
 )
 
 # Install the headers, excluding unit testing related headers

--- a/proxygen/lib/dns/CAresResolver.cpp
+++ b/proxygen/lib/dns/CAresResolver.cpp
@@ -27,9 +27,7 @@ using std::unique_ptr;
 using std::vector;
 
 /* Make sure C-Ares error codes that map to DNS RCODE values are unchanged */
-#if !(ARES_SUCCESS == 0 && ARES_EREFUSED == 6)
-#error "C-Ares status does not map to DNS RCODE values"
-#endif
+static_assert(ARES_SUCCESS == 0 && ARES_EREFUSED == 6, "C-Ares status does not map to DNS RCODE values");
 
 /* Convert a C-Ares status value to an DNS RCODE; -1 for unknown */
 #define ARES_TO_RCODE(x) (((x) <= ARES_EREFUSED) ? (x) : -1)
@@ -161,9 +159,6 @@ void CAresResolver::Query::succeed(std::vector<Answer> answers) {
 
         TraceFieldType lookupType;
         switch (answer.type) {
-          case Answer::AnswerType::AT_TXT:
-            lookupType = TraceFieldType::TXT;
-            break;
           case Answer::AnswerType::AT_ADDRESS:
             lookupType = TraceFieldType::IpAddr;
             break;


### PR DESCRIPTION
Without these changes, the build fails with unresolved symbol failures.

Presumably, this is because `dns/CAresResolver.cpp` and
`dns/CachingDNSResolver.cpp` are referenced in other files that are
being compiled.

We then need to link `cares` because it is used in the two files added
to `PROXYGEN_CORO_SOURCES`.

Finally, we need to replace the `#error` macro with a `static_assert`,
because (at least as of `c-ares` version `1.34.5`) `ARES_SUCCESS` and
`ARES_EREFUSED` are `enum` constants, and therefore not visible to the
preprocessor.

We also drop the reference to `TraceFieldType::TXT` because this
reference doesn't seem to be generated at build time, presumably because
this is not a type included in `lib/utils/samples/TraceFieldType.txt`.

Fixes #573
