### PR TITLE
Rename `libhttperf2` target

### DIFF
--- a/proxygen/httpclient/samples/httperf2/CMakeLists.txt
+++ b/proxygen/httpclient/samples/httperf2/CMakeLists.txt
@@ -4,33 +4,33 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-add_library(libhttperf2 HTTPerf2.cpp Client.cpp)
+add_library(httperf2 HTTPerf2.cpp Client.cpp)
 target_include_directories(
-    libhttperf2 PUBLIC
+    httperf2 PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
 target_compile_options(
-    libhttperf2 PRIVATE
+    httperf2 PRIVATE
     ${_PROXYGEN_COMMON_COMPILE_OPTIONS}
 )
 
 if (BUILD_SHARED_LIBS)
-    set_property(TARGET libhttperf2 PROPERTY POSITION_INDEPENDENT_CODE ON)
+    set_property(TARGET httperf2 PROPERTY POSITION_INDEPENDENT_CODE ON)
     if (DEFINED PACKAGE_VERSION)
         set_target_properties(
-            libhttperf2 PROPERTIES VERSION ${PACKAGE_VERSION}
+            httperf2 PROPERTIES VERSION ${PACKAGE_VERSION}
         )
     endif()
 endif()
 
 target_link_libraries(
-    libhttperf2 PUBLIC
+    httperf2 PUBLIC
     proxygenhqloggerhelper
     proxygen
 )
 
 install(
-    TARGETS libhttperf2
+    TARGETS httperf2
     EXPORT proxygen-exports
     ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
     LIBRARY DESTINATION ${LIB_INSTALL_DIR}
@@ -39,7 +39,7 @@ install(
 add_executable(proxygen_httperf2 Main.cpp)
 target_link_libraries(
     proxygen_httperf2 PUBLIC
-    libhttperf2
+    httperf2
 )
 target_compile_options(
     proxygen_httperf2 PRIVATE


### PR DESCRIPTION
CMake automatically adds a `lib` prefix to library targets, so the
`libhttperf2` target is installed as `liblibhttperf2`.

We can fix that by removing the redundant `lib` prefix in the target
name. This also matches the convention used elsewhere. For example:

    https://github.com/facebook/proxygen/blob/95d64e9423cc25ea49bd817d43eaeed7735ca79a/proxygen/lib/CMakeLists.txt#L153-L154
