### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/publish_mvfst_interop.yml
+++ b/.github/workflows/publish_mvfst_interop.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Log in to the Container registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef  # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -33,12 +33,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@1dc73863535b631f98b2378be8619f83b136f4a0
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6
         with:
           context: .
           file: proxygen/httpserver/samples/hq/quic-interop/Dockerfile


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `docker/build-push-action` | [`1dc7386`](https://github.com/docker/build-push-action/commit/1dc73863535b631f98b2378be8619f83b136f4a0) | [`2634353`](https://github.com/docker/build-push-action/commit/263435318d21b8e681c14492fe198d362a7d2c83) | [Release](https://github.com/docker/build-push-action/releases/tag/v6) | publish_mvfst_interop.yml |
| `docker/login-action` | [`184bdaa`](https://github.com/docker/login-action/commit/184bdaa0721073962dff0199f1fb9940f07167d1) | [`5e57cd1`](https://github.com/docker/login-action/commit/5e57cd118135c172c3672efd75eb46360885c0ef) | [Release](https://github.com/docker/login-action/releases/tag/v3) | publish_mvfst_interop.yml |
| `docker/metadata-action` | [`c1e5197`](https://github.com/docker/metadata-action/commit/c1e51972afc2121e065aed6d45c65596fe445f3f) | [`c299e40`](https://github.com/docker/metadata-action/commit/c299e40c65443455700f0fdfc63efafe5b349051) | [Release](https://github.com/docker/metadata-action/releases/tag/v5) | publish_mvfst_interop.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
