### PR TITLE
Preserve specific error types for ingress errors

### DIFF
--- a/proxygen/httpserver/RequestHandlerAdaptor.cpp
+++ b/proxygen/httpserver/RequestHandlerAdaptor.cpp
@@ -116,7 +116,7 @@ void RequestHandlerAdaptor::onError(const HTTPException& error) noexcept {
           .sendWithEOM();
     }
   } else if (error.getDirection() == HTTPException::Direction::INGRESS) {
-    setError(kErrorRead);
+    setError(error.hasProxygenError() ? error.getProxygenError() : kErrorRead);
 
     if (!txn_->canSendHeaders()) {
       sendAbort(folly::none);


### PR DESCRIPTION
Summary:
Previously, `RequestHandlerAdaptor::onError` would convert ALL ingress
errors to `kErrorRead`, losing the specific error type from the HTTP codec.
For example, a chunked encoding parse error (`kErrorParseBody`) would be
reported as generic `kErrorRead`, making debugging difficult.

This change preserves the specific `ProxygenError` from the `HTTPException`
when available, falling back to `kErrorRead` only when no specific error
is set. This matches the behavior already used for egress errors.

Before: Malformed chunked encoding → `kErrorRead`
After:  Malformed chunked encoding → `kErrorParseBody`

For upload service we log the specific proxygen error but all I saw was "READ" making it difficult to figure out what the actual issue was, seeing "ParseBody" would've made the error clear

Reviewed By: dddmello

Differential Revision: D92352456


