### PR TITLE
Propagate glog compile definitions to OBJECT libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,14 @@ find_package(Threads)
 find_package(c-ares REQUIRED)
 find_package(Glog REQUIRED)
 
+# Propagate glog's required compile definition to all proxygen targets.
+# glog 0.7+ requires GLOG_USE_GLOG_EXPORT but since glog::glog is linked
+# PRIVATE on the monolithic library, OBJECT libraries don't inherit it.
+get_target_property(_glog_defs glog::glog INTERFACE_COMPILE_DEFINITIONS)
+if(_glog_defs)
+  add_compile_definitions(${_glog_defs})
+endif()
+
 list(APPEND
     _PROXYGEN_COMMON_COMPILE_OPTIONS
     -Wall


### PR DESCRIPTION
Summary:
glog 0.7+ requires GLOG_USE_GLOG_EXPORT to be defined before including its headers. In the granular CMake build, glog::glog is linked PRIVATE on the monolithic proxygen library, so its INTERFACE_COMPILE_DEFINITIONS don't propagate to the individual OBJECT libraries. This causes build failures on macOS where homebrew installs glog 0.7+.

After find_package(Glog), read the compile definitions from glog::glog and apply them globally via add_compile_definitions so all proxygen targets get them.

Differential Revision: D93369119


