### PR TITLE
Fixes in build files to allow a smooth macOS build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,8 +93,15 @@ find_package(Zstd REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(Threads)
-find_package(Cares REQUIRED)
 find_package(Glog REQUIRED)
+
+set(CARES_PACKAGE_NAME Cares)
+set(CARES_LIBRARY_NAME cares)
+if (APPLE)
+    set(CARES_PACKAGE_NAME c-ares)
+    set(CARES_LIBRARY_NAME c-ares::cares)
+endif (APPLE)
+find_package(${CARES_PACKAGE_NAME} REQUIRED)
 
 # Propagate glog's required compile definition to all proxygen targets.
 # glog 0.7+ requires GLOG_USE_GLOG_EXPORT but since glog::glog is linked

--- a/build/fbcode_builder/manifests/googletest
+++ b/build/fbcode_builder/manifests/googletest
@@ -7,7 +7,7 @@ sha256 = 65fab701d9829d38cb77c14acdc431d2108bfdbf8979e40eb8ae567edf10b27c
 
 [build]
 builder = cmake
-subdir = googletest-1.17.0
+subdir = googletest-v1.17.0
 
 [cmake.defines]
 # Everything else defaults to the shared runtime, so tell gtest that

--- a/proxygen/build.sh
+++ b/proxygen/build.sh
@@ -272,6 +272,7 @@ function setup_zstd() {
   mkdir -p "$ZSTD_BUILD_DIR"
   cd "$ZSTD_BUILD_DIR" || exit
   cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo           \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.10             \
     -DBUILD_TESTS=OFF                               \
     -DCMAKE_PREFIX_PATH="$ZSTD_INSTALL_DIR"         \
     -DCMAKE_INSTALL_PREFIX="$ZSTD_INSTALL_DIR"      \

--- a/proxygen/build.sh
+++ b/proxygen/build.sh
@@ -361,6 +361,7 @@ function setup_fizz() {
     -DCMAKE_PREFIX_PATH="$DEPS_DIR"             \
     -DCMAKE_INSTALL_PREFIX="$DEPS_DIR"          \
     -DBUILD_TESTS=OFF                           \
+    -DBUILD_EXAMPLES=OFF                        \
     "$MAYBE_USE_STATIC_DEPS"                    \
     "$MAYBE_BUILD_SHARED_LIBS"                  \
     "$MAYBE_OVERRIDE_CXX_FLAGS"                 \

--- a/proxygen/build.sh
+++ b/proxygen/build.sh
@@ -220,7 +220,6 @@ function setup_fmt() {
     -DCMAKE_PREFIX_PATH="$DEPS_DIR"               \
     -DCMAKE_INSTALL_PREFIX="$DEPS_DIR"            \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo             \
-    -DCMAKE_POSITION_INDEPENDENT_CODE=ON          \
     "$MAYBE_OVERRIDE_CXX_FLAGS"                   \
     -DFMT_DOC=OFF                                 \
     -DFMT_TEST=OFF                                \
@@ -247,7 +246,6 @@ function setup_googletest() {
   cd "$GTEST_BUILD_DIR" || exit
 
   cmake                                           \
-    -DCMAKE_POSITION_INDEPENDENT_CODE=ON          \
     -DCMAKE_PREFIX_PATH="$DEPS_DIR"               \
     -DCMAKE_INSTALL_PREFIX="$DEPS_DIR"            \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo             \
@@ -274,7 +272,6 @@ function setup_zstd() {
   mkdir -p "$ZSTD_BUILD_DIR"
   cd "$ZSTD_BUILD_DIR" || exit
   cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo           \
-    -DCMAKE_POSITION_INDEPENDENT_CODE=ON            \
     -DCMAKE_POLICY_VERSION_MINIMUM=3.10             \
     -DBUILD_TESTS=OFF                               \
     -DCMAKE_PREFIX_PATH="$ZSTD_INSTALL_DIR"         \
@@ -324,7 +321,6 @@ function setup_folly() {
   fi
 
   cmake                                           \
-    -DCMAKE_POSITION_INDEPENDENT_CODE=ON          \
     -DCMAKE_PREFIX_PATH="$DEPS_DIR"               \
     -DCMAKE_INSTALL_PREFIX="$DEPS_DIR"            \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo             \
@@ -363,7 +359,6 @@ function setup_fizz() {
   fi
 
   cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo       \
-    -DCMAKE_POSITION_INDEPENDENT_CODE=ON        \
     -DCMAKE_PREFIX_PATH="$DEPS_DIR"             \
     -DCMAKE_INSTALL_PREFIX="$DEPS_DIR"          \
     -DBUILD_TESTS=OFF                           \
@@ -399,7 +394,6 @@ function setup_wangle() {
   fi
 
   cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo       \
-    -DCMAKE_POSITION_INDEPENDENT_CODE=ON        \
     -DCMAKE_PREFIX_PATH="$DEPS_DIR"             \
     -DCMAKE_INSTALL_PREFIX="$DEPS_DIR"          \
     -DBUILD_TESTS=OFF                           \
@@ -434,7 +428,6 @@ function setup_mvfst() {
 
 
   cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo       \
-    -DCMAKE_POSITION_INDEPENDENT_CODE=ON        \
     -DCMAKE_PREFIX_PATH="$DEPS_DIR"             \
     -DCMAKE_INSTALL_PREFIX="$DEPS_DIR"          \
     -DBUILD_TESTS=OFF                           \
@@ -558,7 +551,6 @@ fi
 # Build proxygen with cmake
 cd "$BWD" || exit
 cmake                                     \
-  -DCMAKE_POSITION_INDEPENDENT_CODE=ON    \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo       \
   -DCMAKE_PREFIX_PATH="$DEPS_DIR"         \
   -DCMAKE_INSTALL_PREFIX="$PREFIX"        \

--- a/proxygen/build.sh
+++ b/proxygen/build.sh
@@ -220,6 +220,7 @@ function setup_fmt() {
     -DCMAKE_PREFIX_PATH="$DEPS_DIR"               \
     -DCMAKE_INSTALL_PREFIX="$DEPS_DIR"            \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo             \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON          \
     "$MAYBE_OVERRIDE_CXX_FLAGS"                   \
     -DFMT_DOC=OFF                                 \
     -DFMT_TEST=OFF                                \
@@ -246,6 +247,7 @@ function setup_googletest() {
   cd "$GTEST_BUILD_DIR" || exit
 
   cmake                                           \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON          \
     -DCMAKE_PREFIX_PATH="$DEPS_DIR"               \
     -DCMAKE_INSTALL_PREFIX="$DEPS_DIR"            \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo             \
@@ -272,6 +274,7 @@ function setup_zstd() {
   mkdir -p "$ZSTD_BUILD_DIR"
   cd "$ZSTD_BUILD_DIR" || exit
   cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo           \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON            \
     -DCMAKE_POLICY_VERSION_MINIMUM=3.10             \
     -DBUILD_TESTS=OFF                               \
     -DCMAKE_PREFIX_PATH="$ZSTD_INSTALL_DIR"         \
@@ -321,6 +324,7 @@ function setup_folly() {
   fi
 
   cmake                                           \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON          \
     -DCMAKE_PREFIX_PATH="$DEPS_DIR"               \
     -DCMAKE_INSTALL_PREFIX="$DEPS_DIR"            \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo             \
@@ -359,6 +363,7 @@ function setup_fizz() {
   fi
 
   cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo       \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON        \
     -DCMAKE_PREFIX_PATH="$DEPS_DIR"             \
     -DCMAKE_INSTALL_PREFIX="$DEPS_DIR"          \
     -DBUILD_TESTS=OFF                           \
@@ -394,6 +399,7 @@ function setup_wangle() {
   fi
 
   cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo       \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON        \
     -DCMAKE_PREFIX_PATH="$DEPS_DIR"             \
     -DCMAKE_INSTALL_PREFIX="$DEPS_DIR"          \
     -DBUILD_TESTS=OFF                           \
@@ -428,6 +434,7 @@ function setup_mvfst() {
 
 
   cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo       \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON        \
     -DCMAKE_PREFIX_PATH="$DEPS_DIR"             \
     -DCMAKE_INSTALL_PREFIX="$DEPS_DIR"          \
     -DBUILD_TESTS=OFF                           \
@@ -551,6 +558,7 @@ fi
 # Build proxygen with cmake
 cd "$BWD" || exit
 cmake                                     \
+  -DCMAKE_POSITION_INDEPENDENT_CODE=ON    \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo       \
   -DCMAKE_PREFIX_PATH="$DEPS_DIR"         \
   -DCMAKE_INSTALL_PREFIX="$PREFIX"        \

--- a/proxygen/lib/dns/CMakeLists.txt
+++ b/proxygen/lib/dns/CMakeLists.txt
@@ -61,7 +61,7 @@ proxygen_add_library(proxygen_dns_cares_dns
     proxygen_utils_time_util
     Folly::folly_conv
     Folly::folly_portability_sockets
-    cares
+    ${CARES_LIBRARY_NAME}
     glog::glog
   EXPORTED_DEPS
     proxygen_dns_dns_base
@@ -69,7 +69,7 @@ proxygen_add_library(proxygen_dns_cares_dns
     Folly::folly_io_async_async_base
     Folly::folly_network_address
     Folly::folly_portability_windows
-    cares
+    ${CARES_LIBRARY_NAME}
 )
 
 proxygen_add_library(proxygen_dns_future_dns


### PR DESCRIPTION
The changes fix two issues:
* inability to build the project on macOS via `build.sh` due to 1) incorrect `googletest` folder name in dependencies, 2) absence of a Folly link in Fizz examples, 3) hard failure of `zstd` with newer CMake versions due to policy version enforcement,
* wrong name (on a macOS at least) for the `c-ares` link that propagates to consumer projects.

As a result, on macOS, the project itself can successfully build via `./build.sh`, and can be successfully linked as a dependency.

I did notice one of the [previous commits](https://github.com/facebook/proxygen/commit/5f91bc788b2bc235f2c4abd63c0c8329b99f3fec) that does the opposite to `c-ares` in CMakeLists.txt—so I'm being careful by switching the change only by `if (APPLE)`.