### PR TITLE
Fix StatsWrapper generated output path

### DIFF
--- a/proxygen/lib/CMakeLists.txt
+++ b/proxygen/lib/CMakeLists.txt
@@ -30,11 +30,16 @@ add_custom_command(
 add_custom_command(
     OUTPUT ${PROXYGEN_GENERATED_ROOT}/proxygen/lib/stats/StatsWrapper.h
     COMMAND
+        ${CMAKE_COMMAND} -E make_directory
+        ${PROXYGEN_GENERATED_ROOT}/proxygen/lib/stats
+    COMMAND
         ${CMAKE_CURRENT_SOURCE_DIR}/stats/gen_StatsWrapper.sh
-        ${PROXYGEN_FBCODE_ROOT}
+        ${PROXYGEN_GENERATED_ROOT}
     DEPENDS
+        ${CMAKE_CURRENT_SOURCE_DIR}/stats/gen_StatsWrapper.sh
         ${CMAKE_CURRENT_SOURCE_DIR}/stats/BaseStats.h
     COMMENT "Generating StatsWrapper.h"
+    VERBATIM
 )
 
 add_custom_command(


### PR DESCRIPTION
Summary:
- Generate StatsWrapper.h under PROXYGEN_GENERATED_ROOT, matching the declared custom command output.
- Create the stats output directory before running the generator.
- Track gen_StatsWrapper.sh as an input and use VERBATIM for the command.

The generator writes to $1/proxygen/lib/stats/StatsWrapper.h, but the CMake rule passed PROXYGEN_FBCODE_ROOT while declaring the output below PROXYGEN_GENERATED_ROOT. This makes the generated output not match the declared custom command output.