### PR TITLE
Upgrade gperf to 3.3 in fbcode_builder manifests

### DIFF
--- a/build/fbcode_builder/manifests/gperf
+++ b/build/fbcode_builder/manifests/gperf
@@ -2,12 +2,12 @@
 name = gperf
 
 [download]
-url = https://ftpmirror.gnu.org/gnu/gperf/gperf-3.1.tar.gz
-sha256 = 588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2
+url = https://ftpmirror.gnu.org/gnu/gperf/gperf-3.3.tar.gz
+sha256 = fd87e0aba7e43ae054837afd6cd4db03a3f2693deb3619085e6ed9d8d9604ad8
 
 [build.not(os=windows)]
 builder = autoconf
-subdir = gperf-3.1
+subdir = gperf-3.3
 
 [build.os=windows]
 builder = nop


### PR DESCRIPTION
Summary: Bump gperf from 3.1 to 3.3 in the fbcode_builder manifest and add the corresponding LFS pointer for the new tarball.

Differential Revision: D106373850


