### PR TITLE
Update CMake config to also use find module for c-ares

### DIFF
--- a/cmake/proxygen-config.cmake.in
+++ b/cmake/proxygen-config.cmake.in
@@ -32,7 +32,7 @@ find_dependency(Fizz)
 find_dependency(ZLIB)
 find_dependency(OpenSSL)
 find_dependency(Threads)
-find_dependency(c-ares REQUIRED)
+find_dependency(Cares REQUIRED)
 
 if(NOT TARGET proxygen::proxygen)
     include("${CMAKE_CURRENT_LIST_DIR}/proxygen-targets.cmake")


### PR DESCRIPTION
D93368374 reverted D81248145 to use the find module for c-ares vendored in fbcode_builder instead of c-ares' own CMake config which may be absent when building against system c-ares on older installs (e.g. Ubuntu Jammy).

Do the same for proxygen's CMake config so that projects that depend on proxygen also build against system c-ares in such environments.