### PR TITLE
Add QLoggerFactory support to HQServerTransportFactory

### DIFF
--- a/proxygen/httpserver/samples/hq/HQServer.cpp
+++ b/proxygen/httpserver/samples/hq/HQServer.cpp
@@ -175,7 +175,11 @@ QuicServerTransport::Ptr HQServerTransportFactory::make(
     std::shared_ptr<const FizzServerContext> ctx) noexcept {
   auto transport = quic::QuicHandshakeSocketHolder::makeServerTransport(
       evb, std::move(socket), std::move(ctx), this);
-  if (!params_.qLoggerPath.empty()) {
+  if (qloggerFactory_) {
+    if (auto logger = qloggerFactory_(quic::VantagePoint::Server)) {
+      transport->setQLogger(std::move(logger));
+    }
+  } else if (!params_.qLoggerPath.empty()) {
     transport->setQLogger(std::make_shared<HQLoggerHelper>(
         params_.qLoggerPath, params_.prettyJson, quic::VantagePoint::Server));
   }

--- a/proxygen/httpserver/samples/hq/HQServer.h
+++ b/proxygen/httpserver/samples/hq/HQServer.h
@@ -148,11 +148,18 @@ class HQServerTransportFactory
     , public quic::EarlyDataAppParamsHandler
     , private quic::QuicHandshakeSocketHolder::Callback {
  public:
+  using QLoggerFactory =
+      std::function<std::shared_ptr<quic::QLogger>(quic::VantagePoint)>;
+
   explicit HQServerTransportFactory(
       const HQServerParams& params,
       HTTPTransactionHandlerProvider httpTransactionHandlerProvider,
       std::function<void(proxygen::HQSession*)> onTransportReadyFn_);
   ~HQServerTransportFactory() override = default;
+
+  void setQLoggerFactory(QLoggerFactory fn) {
+    qloggerFactory_ = std::move(fn);
+  }
 
   // Creates new quic server transport
   quic::QuicServerTransport::Ptr make(
@@ -206,6 +213,7 @@ class HQServerTransportFactory
   std::map<std::string, AlpnEntry> alpnHandlers_;
   proxygen::H3EarlyDataHandler h3EarlyDataHandler_;
   quic::EarlyDataAppParamsHandler* defaultEarlyDataHandler_{nullptr};
+  QLoggerFactory qloggerFactory_;
 };
 
 } // namespace quic::samples


### PR DESCRIPTION
This change provides a way for downstream apps like moxygen and moqx to have a configurable qlogger.
Currently, There isn't a straight forward way to enable async logging or log sampling without a wrapper of our own, something like this: https://github.com/openmoq/moxygen/pull/242