### PR TITLE
qmux: deliver byte events on stream write, with tests + CMake wiring

### DIFF
--- a/proxygen/lib/http/coro/transport/CMakeLists.txt
+++ b/proxygen/lib/http/coro/transport/CMakeLists.txt
@@ -36,3 +36,7 @@ proxygen_add_library(proxygen_http_coro_transport_http_connect_transport
     Folly::folly_io_coro_socket
     Folly::folly_logging_logging
 )
+
+if(BUILD_TESTS)
+  add_subdirectory(test)
+endif()

--- a/proxygen/lib/http/coro/transport/test/CMakeLists.txt
+++ b/proxygen/lib/http/coro/transport/test/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+if(NOT BUILD_TESTS)
+    return()
+endif()
+
+# Test-only fake coro transport used by qmux and coro transport tests.
+# Linked against granular proxygen targets (not the monolithic `proxygen`).
+add_library(TestCoroTransport TestCoroTransport.cpp)
+target_include_directories(
+    TestCoroTransport PUBLIC
+    $<BUILD_INTERFACE:${PROXYGEN_FBCODE_ROOT}>
+    $<BUILD_INTERFACE:${PROXYGEN_GENERATED_ROOT}>
+    ${LIBGMOCK_INCLUDE_DIR}
+    ${LIBGTEST_INCLUDE_DIR}
+)
+target_compile_options(
+    TestCoroTransport PRIVATE
+    ${_PROXYGEN_COMMON_COMPILE_OPTIONS}
+)
+target_compile_features(TestCoroTransport PUBLIC cxx_std_20)
+target_link_libraries(TestCoroTransport PUBLIC
+    proxygen_http_coro_util_cancellable_baton
+    Folly::folly
+    Folly::folly_io_coro_socket
+    ${LIBGMOCK_LIBRARIES}
+)

--- a/proxygen/lib/transport/qmux/CMakeLists.txt
+++ b/proxygen/lib/transport/qmux/CMakeLists.txt
@@ -65,3 +65,7 @@ proxygen_add_library(proxygen_transport_qmux_qmux_connector
     proxygen_transport_qmux_qmux_session
     Folly::folly_coro_task
 )
+
+if(BUILD_TESTS)
+  add_subdirectory(test)
+endif()

--- a/proxygen/lib/transport/qmux/QmuxSession.cpp
+++ b/proxygen/lib/transport/qmux/QmuxSession.cpp
@@ -341,11 +341,17 @@ folly::coro::Task<void> QmuxSession::writeLoop(Ptr self) {
           std::min(recordPayloadLimit - recordBytes - kStreamFrameOverhead,
                    maxStreamData);
       auto dequeue = sm.dequeue(*wh, /*atMost=*/atMost);
+      auto* deliveryCallback = dequeue.deliveryCallback;
+      auto deliveredOffset = dequeue.lastByteStreamOffset;
       writeWTStream(recordBuf,
                     WTStreamCapsule{.streamId = id,
                                     .streamData = std::move(dequeue.data),
                                     .fin = dequeue.fin},
                     FrameProtocol::QMUX);
+      // Without this the app's byte-event registration and keepalive leak.
+      if (deliveryCallback) {
+        deliveryCallback->onByteEvent(id, deliveredOffset);
+      }
       wh = sm.nextWritable();
     }
     flushRecord(recordBuf, egressBuf);

--- a/proxygen/lib/transport/qmux/test/CMakeLists.txt
+++ b/proxygen/lib/transport/qmux/test/CMakeLists.txt
@@ -1,0 +1,59 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+if(NOT BUILD_TESTS)
+    return()
+endif()
+
+# These tests link granular proxygen library targets rather than the
+# monolithic `proxygen` target.
+
+proxygen_add_test(TARGET QmuxFramerTest
+  SOURCES
+    QmuxFramerTest.cpp
+  DEPENDS
+    proxygen_transport_qmux_qmux_framer
+    mvfst::mvfst_codec_types
+    mvfst::mvfst_folly_utils
+    testmain
+)
+
+proxygen_add_test(TARGET QmuxCodecTest
+  SOURCES
+    QmuxCodecTest.cpp
+  DEPENDS
+    proxygen_transport_qmux_qmux_codec
+    proxygen_http_codec_webtransport_webtransport_framer
+    proxygen_http_webtransport_wt_stream_manager
+    proxygen_http_webtransport_wt_util
+    mvfst::mvfst_codec_types
+    mvfst::mvfst_priority_http_priority_queue
+    testmain
+)
+
+proxygen_add_test(TARGET QmuxSessionTest
+  SOURCES
+    QmuxSessionTest.cpp
+  DEPENDS
+    proxygen_transport_qmux_qmux_session
+    proxygen_transport_qmux_qmux_codec
+    proxygen_transport_qmux_qmux_framer
+    proxygen_http_codec_webtransport_webtransport_framer
+    proxygen_http_webtransport_wt_stream_manager
+    proxygen_http_webtransport_wt_util
+    TestCoroTransport
+    testmain
+)
+
+proxygen_add_test(TARGET QmuxConnectorTest
+  SOURCES
+    QmuxConnectorTest.cpp
+  DEPENDS
+    proxygen_transport_qmux_qmux_connector
+    proxygen_transport_qmux_qmux_framer
+    TestCoroTransport
+    testmain
+)

--- a/proxygen/lib/transport/qmux/test/QmuxSessionTest.cpp
+++ b/proxygen/lib/transport/qmux/test/QmuxSessionTest.cpp
@@ -214,6 +214,24 @@ class TestWtHandler : public WebTransportHandler {
   folly::Optional<uint32_t> sessionEndError;
 };
 
+//////// Test byte-event callback ////////
+
+// Records the delivery / cancellation events the session fires so a test can
+// assert the app's ByteEventCallback is driven correctly.
+class RecordingByteEventCallback : public WebTransport::ByteEventCallback {
+ public:
+  void onByteEvent(quic::StreamId id, uint64_t offset) noexcept override {
+    byteEvents.emplace_back(id, offset);
+  }
+  void onByteEventCanceled(quic::StreamId id,
+                           uint64_t offset) noexcept override {
+    canceledEvents.emplace_back(id, offset);
+  }
+
+  std::vector<std::pair<quic::StreamId, uint64_t>> byteEvents;
+  std::vector<std::pair<quic::StreamId, uint64_t>> canceledEvents;
+};
+
 //////// Fixture ////////
 
 class QmuxSessionTest : public ::testing::Test {
@@ -490,6 +508,70 @@ TEST_F(QmuxSessionTest, InitialIngress_IsDrainedOnStartup) {
   // Clean shutdown.
   rawTransport->addReadEvent(nullptr, /*eof=*/true);
   drain();
+}
+
+// 10) writeStreamData with a ByteEventCallback fires onByteEvent once the
+//     writeLoop dequeues the buffered write and emits it on the wire.
+//     Regression: the writeLoop previously dropped dequeue.deliveryCallback, so
+//     the app's byte-event registration (and any keepalive it held) leaked and
+//     onByteEvent never fired.
+TEST_F(QmuxSessionTest, WriteWithByteEventCallback_FiresOnByteEvent) {
+  auto created = session_->createBidiStream();
+  ASSERT_TRUE(created.hasValue());
+  const auto streamId = created.value().writeHandle->getID();
+
+  RecordingByteEventCallback byteEventCb;
+  const std::string payload = "byte-event-payload";
+  auto writeResult = created.value().writeHandle->writeStreamData(
+      folly::IOBuf::copyBuffer(payload), /*fin=*/false, &byteEventCb);
+  ASSERT_TRUE(writeResult.hasValue());
+  drain();
+
+  // The data reached the wire without error...
+  parseWrites();
+  EXPECT_TRUE(wire_.cb.connectionErrors.empty());
+
+  // ...and the delivery callback fired exactly once, for this stream, at the
+  // offset of the last delivered byte (payload.size() - 1). Without the fix
+  // byteEvents stays empty.
+  ASSERT_EQ(byteEventCb.byteEvents.size(), 1);
+  EXPECT_EQ(byteEventCb.byteEvents[0].first, streamId);
+  EXPECT_EQ(byteEventCb.byteEvents[0].second, payload.size() - 1);
+  EXPECT_TRUE(byteEventCb.canceledEvents.empty());
+}
+
+// 11) Closing the session cancels the delivery callback of any write still
+//     queued behind flow control: shutdown() -> WriteHandle::cancel() ->
+//     WtBufferedStreamData::clear() fires onByteEventCanceled (not onByteEvent)
+//     so the app's byte-event registration is released rather than leaked.
+TEST_F(QmuxSessionTest, CloseSession_CancelsQueuedByteEvent) {
+  auto created = session_->createBidiStream();
+  ASSERT_TRUE(created.hasValue());
+  const auto streamId = created.value().writeHandle->getID();
+
+  RecordingByteEventCallback byteEventCb;
+  // peerMaxStreamDataBidi is 1<<16; write past it so the tail stays queued
+  // behind stream flow control and the write never fully completes.
+  const std::string payload((1 << 16) + 5000, 'x');
+  auto writeResult = created.value().writeHandle->writeStreamData(
+      folly::IOBuf::copyBuffer(payload), /*fin=*/false, &byteEventCb);
+  ASSERT_TRUE(writeResult.hasValue());
+  drain();
+
+  // The write is incomplete (blocked), so no delivery event has fired yet.
+  EXPECT_TRUE(byteEventCb.byteEvents.empty());
+  EXPECT_TRUE(byteEventCb.canceledEvents.empty());
+
+  // Closing the session must cancel the still-queued byte event.
+  auto res = session_->closeSession(/*error=*/folly::Optional<uint32_t>{42});
+  ASSERT_TRUE(res.hasValue());
+  transport_->addReadEvent(nullptr, /*eof=*/true);
+  drain();
+
+  EXPECT_TRUE(byteEventCb.byteEvents.empty());
+  ASSERT_EQ(byteEventCb.canceledEvents.size(), 1);
+  EXPECT_EQ(byteEventCb.canceledEvents[0].first, streamId);
+  EXPECT_EQ(byteEventCb.canceledEvents[0].second, payload.size() - 1);
 }
 
 TEST_F(QmuxSessionTest, IdleTimer_NotArmedWhenEffectiveTimeoutZero) {


### PR DESCRIPTION
QmuxSession::writeLoop dropped the dequeued delivery callback, so the app's ByteEventCallback registration (and any keepalive it held) leaked and onByteEvent never fired. Fire deliveryCallback->onByteEvent after the buffered write is dequeued and written to the wire.

Add QmuxSessionTest coverage:
- WriteWithByteEventCallback_FiresOnByteEvent: the fix itself.
- CloseSession_CancelsQueuedByteEvent: session close cancels a still queued byte event (shutdown -> WriteHandle::cancel -> clear -> onByteEventCanceled) rather than leaking it.

Wire the qmux tests into CMake (they were buck-only):
- new proxygen/lib/transport/qmux/test/CMakeLists.txt registering all four qmux tests against granular library targets (not the monolithic proxygen target).
- new proxygen/lib/http/coro/transport/test/CMakeLists.txt building the TestCoroTransport test util against granular targets.
- add_subdirectory(test) hooks in the qmux and coro/transport parents.