### PR TITLE
Add publishable proxygen base Docker image

### DIFF
--- a/.github/workflows/publish_base_image.yml
+++ b/.github/workflows/publish_base_image.yml
@@ -1,0 +1,52 @@
+# Following instruction from https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
+
+name: Publish proxygen base image
+
+on:
+  push:
+    tags:
+      # Build a new image weekly with each TagIt release
+      - 'v20*'
+  # Allow rebuilding on demand (e.g. after a dependency bump)
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/base
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@1dc73863535b631f98b2378be8619f83b136f4a0
+        with:
+          context: .
+          file: docker/base.Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -1,0 +1,45 @@
+# Reusable proxygen "base" builder image.
+#
+# Builds proxygen and its full dependency tree (folly, fizz, wangle, mvfst, ...)
+# from the checked-out source with getdeps.py and installs everything under a
+# single CMake prefix at /opt/proxygen. Downstream projects compile against it
+# with no extra flags -- CMAKE_PREFIX_PATH and LD_LIBRARY_PATH are preset:
+#
+#   FROM ghcr.io/facebook/proxygen/base:latest AS build
+#   COPY CMakeLists.txt /app/CMakeLists.txt
+#   COPY src /app/src
+#   RUN cmake -S /app -B /app/build -DCMAKE_BUILD_TYPE=Release && \
+#       cmake --build /app/build -j "$(nproc)"
+#   # find_package(proxygen CONFIG REQUIRED) just works.
+#
+# Published by .github/workflows/publish_base_image.yml.
+# Build locally from the repo root:
+#   docker build -t proxygen-base -f docker/base.Dockerfile .
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+# getdeps installs Python build helpers system-wide inside the container.
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential cmake git g++ make libssl-dev m4 \
+      python3 python3-pip pkg-config sudo ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Build proxygen and all dependencies from the checked-out source.
+COPY . /proxygen
+WORKDIR /proxygen
+RUN ./build/fbcode_builder/getdeps.py install-system-deps --recursive proxygen
+RUN ./build/fbcode_builder/getdeps.py build --allow-system-packages proxygen
+
+# Merge proxygen + every dependency install tree into one CMake prefix, so
+# downstream `find_package(proxygen CONFIG)` resolves with zero extra flags.
+RUN set -eux; \
+    SCRATCH="$(./build/fbcode_builder/getdeps.py show-scratch-dir)"; \
+    mkdir -p /opt/proxygen; \
+    for d in "$SCRATCH"/installed/*/; do cp -a "$d". /opt/proxygen/; done
+
+# Consumers inherit these, so no -DCMAKE_PREFIX_PATH / LD_LIBRARY_PATH needed.
+ENV CMAKE_PREFIX_PATH=/opt/proxygen
+ENV LD_LIBRARY_PATH=/opt/proxygen/lib


### PR DESCRIPTION
Add docker/base.Dockerfile, a reusable builder image that builds proxygen and its dependency tree (folly, fizz, wangle, mvfst, ...) via getdeps and installs everything under a single CMake prefix at /opt/proxygen (CMAKE_PREFIX_PATH and LD_LIBRARY_PATH preset) so downstream find_package(proxygen) works with no extra flags.

Add .github/workflows/publish_base_image.yml to publish it to ghcr.io/facebook/proxygen/base on each TagIt release and on demand, modeled on the existing mvfst-interop publish workflow.