### PR TITLE
Fix apt index refresh in base.Dockerfile before getdeps install-system-deps

### DIFF
--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -30,7 +30,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Build proxygen and all dependencies from the checked-out source.
 COPY . /proxygen
 WORKDIR /proxygen
-RUN ./build/fbcode_builder/getdeps.py install-system-deps --recursive proxygen
+# getdeps' install-system-deps runs `apt-get install` without an `apt-get
+# update`, so refresh the package index (cleared in the layer above) first.
+RUN apt-get update \
+    && ./build/fbcode_builder/getdeps.py install-system-deps --recursive proxygen \
+    && rm -rf /var/lib/apt/lists/*
 RUN ./build/fbcode_builder/getdeps.py build --allow-system-packages proxygen
 
 # Merge proxygen + every dependency install tree into one CMake prefix, so


### PR DESCRIPTION
The prior layer clears /var/lib/apt/lists/*, and getdeps' install-system-deps runs `apt-get install` without an `apt-get update`, leaving apt with an empty package index. This caused every system dep to fail with 'Unable to locate package'. Refresh the index before the install step and re-clean it afterward.